### PR TITLE
JSON Schemea Endpoints

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -66,6 +66,22 @@
   revision = "e6d60cf7ba1f42d86d54cdf5508611c4aafb3970"
   version = "v0.0.1"
 
+[[projects]]
+  digest = "1:d235e49bf6cae4fe6a794352b5e74656f9e3c15b1f6b097b0382865414110e2e"
+  name = "github.com/qri-io/jsonpointer"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "43be820608971e680b60469cfc7cc0e2e75fd4ef"
+  version = "v0.1.0"
+
+[[projects]]
+  digest = "1:86a61771e3006eeb78ab8a7942c3a9dbae1aca96ab48df505357a6a93f7bc3fa"
+  name = "github.com/qri-io/jsonschema"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "b244d4b99401d163bd9e382fd58698794259d091"
+  version = "v0.1.1"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
@@ -75,6 +91,7 @@
     "github.com/gofrs/uuid",
     "github.com/jawher/mow.cli",
     "github.com/olekukonko/tablewriter",
+    "github.com/qri-io/jsonschema",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/schema.go
+++ b/schema.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/qri-io/jsonschema"
+)
+
+type Schema struct {
+	*Conch
+}
+
+func (c *Conch) Schema() *Schema {
+	return &Schema{c}
+}
+
+func (s *Schema) Get(name string) *jsonschema.RootSchema {
+	uri := fmt.Sprintf("/schema/%s", name)
+	rs := &jsonschema.RootSchema{}
+
+	// for now we completely skip our internal HTTP handling and just use sling directly
+	_, err := s.Sling().Get(uri).Receive(&rs, nil)
+	if err != nil {
+		panic(err)
+	}
+	return rs
+}

--- a/schema_test.go
+++ b/schema_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestJSONSchemaGet(t *testing.T) {
+	name := "request/Login"
+	valid := []byte(`{
+		"email":"test@example.com",
+		"password":"123456"
+	}`)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// output from the API's '/schema/request/Login` endpoint
+		fmt.Fprintf(w, `
+			{
+				"$id":"urn:request.Login.schema.json",
+				"$schema":"http:\/\/json-schema.org\/draft-07\/schema#",
+				"additionalProperties":false,
+				"definitions":{
+					"email_address":{
+						"allOf":[
+							{"format":"email","type":"string"},
+							{"$ref":"\/definitions\/mojo_relaxed_placeholder"}
+						]
+					},
+					"mojo_relaxed_placeholder":{
+						"description":"see https:\/\/metacpan.org\/pod\/Mojolicious::Guides::Routing#Relaxed-placeholders",
+						"pattern":"^[^\/]+$","type":"string"
+					},
+					"non_empty_string":{
+						"minLength":1,
+						"type":"string"
+					},
+					"uuid":{
+						"pattern":"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+						"type":"string"
+					}
+				},
+				"oneOf":[
+					{"required":["user_id"]},
+					{"required":["email"]}
+				],
+				"properties":{
+					"email":{"$ref":"\/definitions\/email_address"},
+					"password":{"$ref":"\/definitions\/non_empty_string"},
+					"user_id":{"$ref":"\/definitions\/uuid"}},
+					"required":["password"],
+					"title":"Login",
+					"type":"object"
+			}
+	`)
+	}))
+
+	API.URL = server.URL
+	rs := API.Schema().Get(name)
+
+	if rs == nil {
+		t.Fatalf("Couldn't get root schema")
+	}
+
+	if errors, _ := rs.ValidateBytes(valid); len(errors) > 0 {
+		t.Errorf("Couldn't validate valid JSON: %v", errors)
+	}
+}


### PR DESCRIPTION
This allows us to fetch the schema definitons from the conch API
and (potentially) validate against them. This should improve our
tests in other branches by testing against live schemas.