### PR TITLE
Clean up output for Hardware CLI

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -89,6 +89,14 @@
   version = "v0.0.1"
 
 [[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  pruneopts = "UT"
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:d235e49bf6cae4fe6a794352b5e74656f9e3c15b1f6b097b0382865414110e2e"
   name = "github.com/qri-io/jsonpointer"
   packages = ["."]
@@ -103,6 +111,14 @@
   pruneopts = "UT"
   revision = "b244d4b99401d163bd9e382fd58698794259d091"
   version = "v0.1.1"
+
+[[projects]]
+  digest = "1:8548c309c65a85933a625be5e7d52b6ac927ca30c56869fae58123b8a77a75e1"
+  name = "github.com/stretchr/testify"
+  packages = ["assert"]
+  pruneopts = "UT"
+  revision = "221dbe5ed46703ee255b1da0dec05086f5035f62"
+  version = "v1.4.0"
 
 [[projects]]
   digest = "1:59f10c1537d2199d9115d946927fe31165959a95190849c82ff11e05803528b0"
@@ -125,6 +141,7 @@
     "github.com/jawher/mow.cli",
     "github.com/olekukonko/tablewriter",
     "github.com/qri-io/jsonschema",
+    "github.com/stretchr/testify/assert",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/builds_test.go
+++ b/builds_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBuildsGetAll(t *testing.T) {
@@ -28,7 +30,7 @@ func TestBuildsGetAll(t *testing.T) {
 
 	assertRequestCount(t, spy.requestCount, 1)
 	assertRequestPath(t, spy.requestPath, "/build")
-	assertData(t, got, buildList)
+	assert.Equal(t, got, buildList)
 }
 
 func TestBuildsGet(t *testing.T) {
@@ -49,7 +51,7 @@ func TestBuildsGet(t *testing.T) {
 	assertRequestMethod(t, spy.requestMethod, "GET")
 	assertRequestCount(t, spy.requestCount, 1)
 	assertRequestPath(t, spy.requestPath, fmt.Sprintf("/build/%s", build.ID))
-	assertData(t, got, build)
+	assert.Equal(t, got, build)
 }
 
 func TestBuildsGetByName(t *testing.T) {
@@ -70,7 +72,7 @@ func TestBuildsGetByName(t *testing.T) {
 	assertRequestMethod(t, spy.requestMethod, "GET")
 	assertRequestCount(t, spy.requestCount, 1)
 	assertRequestPath(t, spy.requestPath, fmt.Sprintf("/build/%s", build.Name))
-	assertData(t, got, build)
+	assert.Equal(t, got, build)
 }
 
 func TestBuildsCreate(t *testing.T) {
@@ -100,7 +102,7 @@ func TestBuildsCreate(t *testing.T) {
 	}
 
 	// now let's check what we made in the server is what we got in the client
-	assertData(t, got, want)
+	assert.Equal(t, got, want)
 }
 
 func TestBuildsGetUsers(t *testing.T) {
@@ -123,7 +125,7 @@ func TestBuildsGetUsers(t *testing.T) {
 	assertRequestMethod(t, spy.requestMethod, "GET")
 	assertRequestCount(t, spy.requestCount, 1)
 	assertRequestPath(t, spy.requestPath, fmt.Sprintf("/build/%s/user", build.ID))
-	assertData(t, got, list)
+	assert.Equal(t, got, list)
 }
 
 func TestBuildsAddUser(t *testing.T) {
@@ -191,7 +193,7 @@ func TestBuildsGetOrgs(t *testing.T) {
 	assertRequestMethod(t, spy.requestMethod, "GET")
 	assertRequestCount(t, spy.requestCount, 1)
 	assertRequestPath(t, spy.requestPath, fmt.Sprintf("/build/%s/organization", build.ID))
-	assertData(t, got, list)
+	assert.Equal(t, got, list)
 }
 
 func TestBuildsAddOrg(t *testing.T) {
@@ -259,7 +261,7 @@ func TestBuildsGetDevices(t *testing.T) {
 	assertRequestMethod(t, spy.requestMethod, "GET")
 	assertRequestCount(t, spy.requestCount, 1)
 	assertRequestPath(t, spy.requestPath, fmt.Sprintf("/build/%s/device", build.ID))
-	assertData(t, got, list)
+	assert.Equal(t, got, list)
 }
 
 func TestBuildsAddDevice(t *testing.T) {
@@ -327,7 +329,7 @@ func TestBuildsGetRacks(t *testing.T) {
 	assertRequestMethod(t, spy.requestMethod, "GET")
 	assertRequestCount(t, spy.requestCount, 1)
 	assertRequestPath(t, spy.requestPath, fmt.Sprintf("/build/%s/rack", build.ID))
-	assertData(t, got, list)
+	assert.Equal(t, got, list)
 }
 
 func TestBuildsAddRack(t *testing.T) {

--- a/devices.go
+++ b/devices.go
@@ -180,7 +180,7 @@ type DeviceLocation struct {
 	RackName              string `json:"rack"`
 	RackUnitStart         int    `json:"rack_unit_start" faker:"rack_unit_start"`
 	TargetHardwareProduct struct {
-		ID     uuid.UUID `json:"id" faker"uuid"`
+		ID     uuid.UUID `json:"id" faker:"uuid"`
 		Name   string    `json:"name"`
 		Alias  string    `json:"alias"`
 		Vendor string    `json:"hardware_vendor_id"`

--- a/errors.go
+++ b/errors.go
@@ -31,7 +31,7 @@ func errorHandler() {
 					fmt.Println(err)
 				}
 				fmt.Fprintf(os.Stderr,
-					"HTTP Request: %s",
+					"HTTP Request: %s\n\n",
 					reqDump,
 				)
 

--- a/fixtures/conch-v3/device.yaml
+++ b/fixtures/conch-v3/device.yaml
@@ -7,7 +7,37 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/hardware_vendor/MyNewVendor
+    url: http://10.51.54.42:5000/hardware_vendor/MyBigVendor
+    method: GET
+  response:
+    body: '{"error":"Entity Not Found"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "28"
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 26 Jan 2020 19:04:25 GMT
+      Request-Id:
+      - qWH9gOZPxm+0
+      Server:
+      - Mojolicious (Perl)
+      X-Conch-Api:
+      - v3.0.0-b4-0-gb99fbfff
+      X-Request-Id:
+      - qWH9gOZPxm+0
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Conch/3.x-testing
+    url: http://10.51.54.42:5000/hardware_vendor/MyBigVendor
     method: POST
   response:
     body: ""
@@ -17,15 +47,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Mon, 13 Jan 2020 23:16:20 GMT
+      - Sun, 26 Jan 2020 19:04:25 GMT
       Location:
-      - /hardware_vendor/MyNewVendor
+      - /hardware_vendor/MyBigVendor
       Request-Id:
-      - fPL/c03jql82
+      - fonfGbizHibf
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - fPL/c03jql82
+      - fonfGbizHibf
     status: 303 See Other
     code: 303
     duration: ""
@@ -34,13 +64,13 @@ interactions:
     form: {}
     headers:
       Referer:
-      - http://10.51.54.42:5000/hardware_vendor/MyNewVendor
+      - http://10.51.54.42:5000/hardware_vendor/MyBigVendor
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/hardware_vendor/MyNewVendor
+    url: http://10.51.54.42:5000/hardware_vendor/MyBigVendor
     method: GET
   response:
-    body: '{"created":"2020-01-13T23:16:20.561379Z","id":"97c61378-695e-4966-8006-90531f1717c5","name":"MyNewVendor","updated":"2020-01-13T23:16:20.561379Z"}'
+    body: '{"created":"2020-01-26T19:04:25.777925Z","id":"713e2342-ed15-409d-a07c-bbca41941d92","name":"MyBigVendor","updated":"2020-01-26T19:04:25.777925Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -49,15 +79,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:20 GMT
+      - Sun, 26 Jan 2020 19:04:25 GMT
       Request-Id:
-      - qHn7XcIwUMAs
+      - FAJrBEVlyK3I
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - qHn7XcIwUMAs
+      - FAJrBEVlyK3I
     status: 200 OK
     code: 200
     duration: ""
@@ -67,10 +97,10 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/hardware_vendor/MyNewVendor
+    url: http://10.51.54.42:5000/hardware_vendor/MyBigVendor
     method: GET
   response:
-    body: '{"created":"2020-01-13T23:16:20.561379Z","id":"97c61378-695e-4966-8006-90531f1717c5","name":"MyNewVendor","updated":"2020-01-13T23:16:20.561379Z"}'
+    body: '{"created":"2020-01-26T19:04:25.777925Z","id":"713e2342-ed15-409d-a07c-bbca41941d92","name":"MyBigVendor","updated":"2020-01-26T19:04:25.777925Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -79,15 +109,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:20 GMT
+      - Sun, 26 Jan 2020 19:04:25 GMT
       Request-Id:
-      - w4qBcL9GVCAb
+      - i831ckqZQrd4
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - w4qBcL9GVCAb
+      - i831ckqZQrd4
     status: 200 OK
     code: 200
     duration: ""
@@ -111,21 +141,21 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:20 GMT
+      - Sun, 26 Jan 2020 19:04:25 GMT
       Request-Id:
-      - 3KsI9tziUhF2
+      - eG/SeT99BegJ
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - 3KsI9tziUhF2
+      - eG/SeT99BegJ
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"alias":"VJyvwevrxySZAvrKjrbtbgYyq","bios_firmware":"VzYgMZEqAUNABMDwZRJiNIqZg","cpu_type":"vbmXmDGagjdhfIHLKaKQejKrn","hardware_vendor_id":"97c61378-695e-4966-8006-90531f1717c5","name":"jTVlTCMbVYzTzKzcsknuluMWJ","purpose":"LARDMlEVwBkvfEhTEVHlHvigy","rack_unit_size":1,"sku":"UqTmNGrfLtSTWvblmGqUEjIqq","validation_plan_id":"a30ab8b2-8a9e-4e51-8bb0-92862abd8b54"}
+      {"alias":"VgvjJOOnrRwUYxWQFOtemUQuQ","bios_firmware":"XqkAkCZYLvgRLvYqIrtHPFhVN","cpu_type":"AjbeLNHApsBhqcpiSwSZtssQx","hardware_vendor_id":"713e2342-ed15-409d-a07c-bbca41941d92","name":"KPHacrRjdKTXHRQkYFizhiXiJ","purpose":"uNggImrxtZCFRXriVRahxKFvd","rack_unit_size":2,"sku":"xYxLsvSQYDsWVAxNTrUcxHIgL","validation_plan_id":"a30ab8b2-8a9e-4e51-8bb0-92862abd8b54"}
     form: {}
     headers:
       Content-Type:
@@ -142,15 +172,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Mon, 13 Jan 2020 23:16:20 GMT
+      - Sun, 26 Jan 2020 19:04:25 GMT
       Location:
-      - /hardware_product/aec8b534-e365-4ea1-b297-e0cc77247671
+      - /hardware_product/2eca6269-a424-45f2-a3a9-a9913b8976ba
       Request-Id:
-      - 6KKlEe+Fvltt
+      - jhGk7EV8f4r3
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - 6KKlEe+Fvltt
+      - jhGk7EV8f4r3
     status: 303 See Other
     code: 303
     duration: ""
@@ -164,10 +194,10 @@ interactions:
       - http://10.51.54.42:5000/hardware_product
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/hardware_product/aec8b534-e365-4ea1-b297-e0cc77247671
+    url: http://10.51.54.42:5000/hardware_product/2eca6269-a424-45f2-a3a9-a9913b8976ba
     method: GET
   response:
-    body: '{"alias":"VJyvwevrxySZAvrKjrbtbgYyq","bios_firmware":"VzYgMZEqAUNABMDwZRJiNIqZg","cpu_num":0,"cpu_type":"vbmXmDGagjdhfIHLKaKQejKrn","created":"2020-01-13T23:16:20.655148Z","dimms_num":0,"generation_name":null,"hardware_vendor_id":"97c61378-695e-4966-8006-90531f1717c5","hba_firmware":null,"id":"aec8b534-e365-4ea1-b297-e0cc77247671","legacy_product_name":null,"name":"jTVlTCMbVYzTzKzcsknuluMWJ","nics_num":0,"nvme_ssd_num":0,"nvme_ssd_size":null,"nvme_ssd_slots":null,"prefix":null,"psu_total":0,"purpose":"LARDMlEVwBkvfEhTEVHlHvigy","rack_unit_size":1,"raid_lun_num":0,"ram_total":0,"sas_hdd_num":0,"sas_hdd_size":null,"sas_hdd_slots":null,"sas_ssd_num":0,"sas_ssd_size":null,"sas_ssd_slots":null,"sata_hdd_num":0,"sata_hdd_size":null,"sata_hdd_slots":null,"sata_ssd_num":0,"sata_ssd_size":null,"sata_ssd_slots":null,"sku":"UqTmNGrfLtSTWvblmGqUEjIqq","specification":null,"updated":"2020-01-13T23:16:20.655148Z","usb_num":0,"validation_plan_id":"a30ab8b2-8a9e-4e51-8bb0-92862abd8b54"}'
+    body: '{"alias":"VgvjJOOnrRwUYxWQFOtemUQuQ","bios_firmware":"XqkAkCZYLvgRLvYqIrtHPFhVN","cpu_num":0,"cpu_type":"AjbeLNHApsBhqcpiSwSZtssQx","created":"2020-01-26T19:04:25.859308Z","dimms_num":0,"generation_name":null,"hardware_vendor_id":"713e2342-ed15-409d-a07c-bbca41941d92","hba_firmware":null,"id":"2eca6269-a424-45f2-a3a9-a9913b8976ba","legacy_product_name":null,"name":"KPHacrRjdKTXHRQkYFizhiXiJ","nics_num":0,"nvme_ssd_num":0,"nvme_ssd_size":null,"nvme_ssd_slots":null,"prefix":null,"psu_total":0,"purpose":"uNggImrxtZCFRXriVRahxKFvd","rack_unit_size":2,"raid_lun_num":0,"ram_total":0,"sas_hdd_num":0,"sas_hdd_size":null,"sas_hdd_slots":null,"sas_ssd_num":0,"sas_ssd_size":null,"sas_ssd_slots":null,"sata_hdd_num":0,"sata_hdd_size":null,"sata_hdd_slots":null,"sata_ssd_num":0,"sata_ssd_size":null,"sata_ssd_slots":null,"sku":"xYxLsvSQYDsWVAxNTrUcxHIgL","specification":null,"updated":"2020-01-26T19:04:25.859308Z","usb_num":0,"validation_plan_id":"a30ab8b2-8a9e-4e51-8bb0-92862abd8b54"}'
     headers:
       Cache-Control:
       - no-cache
@@ -176,23 +206,23 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:20 GMT
+      - Sun, 26 Jan 2020 19:04:25 GMT
       Location:
-      - /hardware_product/aec8b534-e365-4ea1-b297-e0cc77247671
+      - /hardware_product/2eca6269-a424-45f2-a3a9-a9913b8976ba
       Request-Id:
-      - ERX8B9hLxp7c
+      - mKxPAnvfFv6f
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - ERX8B9hLxp7c
+      - mKxPAnvfFv6f
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"alias":"yerxeoFNWksgibkdHLxDxllXg","bios_firmware":"NawnRveLsMFQdIuSGBLbxLtql","cpu_type":"qWfcfIsgXLkCwKkqJcLmbpDvo","hardware_vendor_id":"97c61378-695e-4966-8006-90531f1717c5","name":"DkDGSlKRDwYsrZzQLXplUuRFb","purpose":"HoZVKqacdWpIAxqjXrVthDqPw","rack_unit_size":2,"sku":"RcDuMOWzWSOrhAzFErsMTSMko","validation_plan_id":"a30ab8b2-8a9e-4e51-8bb0-92862abd8b54"}
+      {"alias":"fZUdZGfPTpNuoaETCoAXHzHdh","bios_firmware":"KDvLhxavVmQzskmemwXPdBUrb","cpu_type":"NhgfDfTpxIeGdtBbqqFVpflLH","hardware_vendor_id":"713e2342-ed15-409d-a07c-bbca41941d92","name":"ZLepZJcnMPSuCGgjCKATuzdbm","purpose":"QrtEnSloWHelCmwPRFIzWToNy","rack_unit_size":1,"sku":"FxCjKnuMmPTawRhYMJmKDWwrN","validation_plan_id":"a30ab8b2-8a9e-4e51-8bb0-92862abd8b54"}
     form: {}
     headers:
       Content-Type:
@@ -209,15 +239,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Mon, 13 Jan 2020 23:16:20 GMT
+      - Sun, 26 Jan 2020 19:04:25 GMT
       Location:
-      - /hardware_product/bb2996d4-b990-41f4-b073-2445969bea97
+      - /hardware_product/6621614d-ad3d-42f7-8a6d-3cb94d8bd76e
       Request-Id:
-      - 4b4OY4NW0BBI
+      - PAJPT2jJuxYC
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - 4b4OY4NW0BBI
+      - PAJPT2jJuxYC
     status: 303 See Other
     code: 303
     duration: ""
@@ -231,10 +261,10 @@ interactions:
       - http://10.51.54.42:5000/hardware_product
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/hardware_product/bb2996d4-b990-41f4-b073-2445969bea97
+    url: http://10.51.54.42:5000/hardware_product/6621614d-ad3d-42f7-8a6d-3cb94d8bd76e
     method: GET
   response:
-    body: '{"alias":"yerxeoFNWksgibkdHLxDxllXg","bios_firmware":"NawnRveLsMFQdIuSGBLbxLtql","cpu_num":0,"cpu_type":"qWfcfIsgXLkCwKkqJcLmbpDvo","created":"2020-01-13T23:16:20.713808Z","dimms_num":0,"generation_name":null,"hardware_vendor_id":"97c61378-695e-4966-8006-90531f1717c5","hba_firmware":null,"id":"bb2996d4-b990-41f4-b073-2445969bea97","legacy_product_name":null,"name":"DkDGSlKRDwYsrZzQLXplUuRFb","nics_num":0,"nvme_ssd_num":0,"nvme_ssd_size":null,"nvme_ssd_slots":null,"prefix":null,"psu_total":0,"purpose":"HoZVKqacdWpIAxqjXrVthDqPw","rack_unit_size":2,"raid_lun_num":0,"ram_total":0,"sas_hdd_num":0,"sas_hdd_size":null,"sas_hdd_slots":null,"sas_ssd_num":0,"sas_ssd_size":null,"sas_ssd_slots":null,"sata_hdd_num":0,"sata_hdd_size":null,"sata_hdd_slots":null,"sata_ssd_num":0,"sata_ssd_size":null,"sata_ssd_slots":null,"sku":"RcDuMOWzWSOrhAzFErsMTSMko","specification":null,"updated":"2020-01-13T23:16:20.713808Z","usb_num":0,"validation_plan_id":"a30ab8b2-8a9e-4e51-8bb0-92862abd8b54"}'
+    body: '{"alias":"fZUdZGfPTpNuoaETCoAXHzHdh","bios_firmware":"KDvLhxavVmQzskmemwXPdBUrb","cpu_num":0,"cpu_type":"NhgfDfTpxIeGdtBbqqFVpflLH","created":"2020-01-26T19:04:25.923019Z","dimms_num":0,"generation_name":null,"hardware_vendor_id":"713e2342-ed15-409d-a07c-bbca41941d92","hba_firmware":null,"id":"6621614d-ad3d-42f7-8a6d-3cb94d8bd76e","legacy_product_name":null,"name":"ZLepZJcnMPSuCGgjCKATuzdbm","nics_num":0,"nvme_ssd_num":0,"nvme_ssd_size":null,"nvme_ssd_slots":null,"prefix":null,"psu_total":0,"purpose":"QrtEnSloWHelCmwPRFIzWToNy","rack_unit_size":1,"raid_lun_num":0,"ram_total":0,"sas_hdd_num":0,"sas_hdd_size":null,"sas_hdd_slots":null,"sas_ssd_num":0,"sas_ssd_size":null,"sas_ssd_slots":null,"sata_hdd_num":0,"sata_hdd_size":null,"sata_hdd_slots":null,"sata_ssd_num":0,"sata_ssd_size":null,"sata_ssd_slots":null,"sku":"FxCjKnuMmPTawRhYMJmKDWwrN","specification":null,"updated":"2020-01-26T19:04:25.923019Z","usb_num":0,"validation_plan_id":"a30ab8b2-8a9e-4e51-8bb0-92862abd8b54"}'
     headers:
       Cache-Control:
       - no-cache
@@ -243,23 +273,23 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:20 GMT
+      - Sun, 26 Jan 2020 19:04:25 GMT
       Location:
-      - /hardware_product/bb2996d4-b990-41f4-b073-2445969bea97
+      - /hardware_product/6621614d-ad3d-42f7-8a6d-3cb94d8bd76e
       Request-Id:
-      - MQUUJqstrttA
+      - UzaWSuNSqe1y
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - MQUUJqstrttA
+      - UzaWSuNSqe1y
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"location":"JZFXTjfgRvgDsoewYrayWliST","region":"xTrXVPfKvaFxKkVdGHhHyARmS","vendor":"lwsPfHerGpzoJhMSEKDiNrYhJ","vendor_name":"OpEnylzCVdIGYPjZKVEIWGDBg"}
+      {"location":"wVUkuFBhOkeuJjPIMOuKFFCtq","region":"mVQptcFUoeCvPUAmWRFQWAAtL","vendor":"raufanYXyJBEiiKSSHtQcmMfO","vendor_name":"DdVxUofQpudwRdHoXPtjYHVri"}
     form: {}
     headers:
       Content-Type:
@@ -276,15 +306,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Mon, 13 Jan 2020 23:16:20 GMT
+      - Sun, 26 Jan 2020 19:04:25 GMT
       Location:
-      - /dc/5e509013-7894-4e0e-a9bb-3e71d9f402c9
+      - /dc/bc85ceef-2d58-45ae-a659-1b666f794795
       Request-Id:
-      - UrveSZWafJKi
+      - 16IfPczqe5tG
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - UrveSZWafJKi
+      - 16IfPczqe5tG
     status: 201 Created
     code: 201
     duration: ""
@@ -294,10 +324,10 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/dc/5e509013-7894-4e0e-a9bb-3e71d9f402c9
+    url: http://10.51.54.42:5000/dc/bc85ceef-2d58-45ae-a659-1b666f794795
     method: GET
   response:
-    body: '{"created":"2020-01-13T23:16:20.762799Z","id":"5e509013-7894-4e0e-a9bb-3e71d9f402c9","location":"JZFXTjfgRvgDsoewYrayWliST","region":"xTrXVPfKvaFxKkVdGHhHyARmS","updated":"2020-01-13T23:16:20.762799Z","vendor":"lwsPfHerGpzoJhMSEKDiNrYhJ","vendor_name":"OpEnylzCVdIGYPjZKVEIWGDBg"}'
+    body: '{"created":"2020-01-26T19:04:25.970655Z","id":"bc85ceef-2d58-45ae-a659-1b666f794795","location":"wVUkuFBhOkeuJjPIMOuKFFCtq","region":"mVQptcFUoeCvPUAmWRFQWAAtL","updated":"2020-01-26T19:04:25.970655Z","vendor":"raufanYXyJBEiiKSSHtQcmMfO","vendor_name":"DdVxUofQpudwRdHoXPtjYHVri"}'
     headers:
       Cache-Control:
       - no-cache
@@ -306,21 +336,21 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:20 GMT
+      - Sun, 26 Jan 2020 19:04:25 GMT
       Request-Id:
-      - h4pPbRjQHgQ1
+      - djkc/WI3xJyV
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - h4pPbRjQHgQ1
+      - djkc/WI3xJyV
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"alias":"oySHUJEZhDYJoZkRrWAiGdpkU","az":"VJiGAAwpXmKZsuVUEGZCfEMcj","datacenter_id":"5e509013-7894-4e0e-a9bb-3e71d9f402c9","vendor_name":"FnhzTeQgWlNnEqlVtMgGBWNYs"}
+      {"alias":"YZScFfGvMadGNUUBxvuztEhmc","az":"rSHTRbXlBtZUUPZowzIXvGTtU","datacenter_id":"bc85ceef-2d58-45ae-a659-1b666f794795","vendor_name":"zNHMvLDMgbkfUIPtAhglCOwTg"}
     form: {}
     headers:
       Content-Type:
@@ -337,15 +367,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Mon, 13 Jan 2020 23:16:20 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Location:
-      - /room/724a6c54-9676-4169-8475-728866852b43
+      - /room/89ce0266-20fe-4136-a772-e2d9ace8d956
       Request-Id:
-      - 50OSzigzDwna
+      - oEoP5M4Z5O/c
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - 50OSzigzDwna
+      - oEoP5M4Z5O/c
     status: 303 See Other
     code: 303
     duration: ""
@@ -359,10 +389,10 @@ interactions:
       - http://10.51.54.42:5000/room
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/room/724a6c54-9676-4169-8475-728866852b43
+    url: http://10.51.54.42:5000/room/89ce0266-20fe-4136-a772-e2d9ace8d956
     method: GET
   response:
-    body: '{"alias":"oySHUJEZhDYJoZkRrWAiGdpkU","az":"VJiGAAwpXmKZsuVUEGZCfEMcj","created":"2020-01-13T23:16:20.803937Z","datacenter_id":"5e509013-7894-4e0e-a9bb-3e71d9f402c9","id":"724a6c54-9676-4169-8475-728866852b43","updated":"2020-01-13T23:16:20.803937Z","vendor_name":"FnhzTeQgWlNnEqlVtMgGBWNYs"}'
+    body: '{"alias":"YZScFfGvMadGNUUBxvuztEhmc","az":"rSHTRbXlBtZUUPZowzIXvGTtU","created":"2020-01-26T19:04:26.008325Z","datacenter_id":"bc85ceef-2d58-45ae-a659-1b666f794795","id":"89ce0266-20fe-4136-a772-e2d9ace8d956","updated":"2020-01-26T19:04:26.008325Z","vendor_name":"zNHMvLDMgbkfUIPtAhglCOwTg"}'
     headers:
       Cache-Control:
       - no-cache
@@ -371,23 +401,23 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:20 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Location:
-      - /room/724a6c54-9676-4169-8475-728866852b43
+      - /room/89ce0266-20fe-4136-a772-e2d9ace8d956
       Request-Id:
-      - sWAR52hriBW0
+      - SIn+zxbhU4hQ
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - sWAR52hriBW0
+      - SIn+zxbhU4hQ
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"admins":[{"email":"conch@example.com"}],"description":"AvLXNFRKvRHxFTvZFtcmCkEaW","name":"oXtNiTcABrbXxQiTPGcxqqodP"}
+      {"admins":[{"email":"conch@example.com"}],"description":"XZPonJXYDzKogdPMyeIjmkYpX","name":"JIrULNPxKPKZncyExKMfLfGcY"}
     form: {}
     headers:
       Content-Type:
@@ -404,15 +434,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Mon, 13 Jan 2020 23:16:20 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Location:
-      - /build/68147506-b332-4471-8ec7-525680545366
+      - /build/7d2b96d4-3b2a-4a24-9fb9-fbfddf35dcc9
       Request-Id:
-      - kFdfcnynY8ZZ
+      - K5WUjtWhPPs0
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - kFdfcnynY8ZZ
+      - K5WUjtWhPPs0
     status: 303 See Other
     code: 303
     duration: ""
@@ -426,10 +456,10 @@ interactions:
       - http://10.51.54.42:5000/build
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/build/68147506-b332-4471-8ec7-525680545366
+    url: http://10.51.54.42:5000/build/7d2b96d4-3b2a-4a24-9fb9-fbfddf35dcc9
     method: GET
   response:
-    body: '{"admins":[{"email":"conch@example.com","id":"1ebc992d-ced6-47fa-be0c-3f966a9eb42f","name":"Kosh"}],"completed":null,"completed_user":null,"created":"2020-01-13T23:16:20.851360Z","description":"AvLXNFRKvRHxFTvZFtcmCkEaW","id":"68147506-b332-4471-8ec7-525680545366","name":"oXtNiTcABrbXxQiTPGcxqqodP","started":null}'
+    body: '{"admins":[{"email":"conch@example.com","id":"1ebc992d-ced6-47fa-be0c-3f966a9eb42f","name":"Kosh"}],"completed":null,"completed_user":null,"created":"2020-01-26T19:04:26.049247Z","description":"XZPonJXYDzKogdPMyeIjmkYpX","id":"7d2b96d4-3b2a-4a24-9fb9-fbfddf35dcc9","name":"JIrULNPxKPKZncyExKMfLfGcY","started":null}'
     headers:
       Cache-Control:
       - no-cache
@@ -438,21 +468,21 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:20 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Request-Id:
-      - 5nZC0/xSmAXq
+      - /uABG1jTI8i6
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - 5nZC0/xSmAXq
+      - /uABG1jTI8i6
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"name":"kToauJTemcomWdudOSSYtCMDb","rack_size":60}
+      {"name":"PsSRIniTNebDKOEpDnzQrZASj","rack_size":60}
     form: {}
     headers:
       Content-Type:
@@ -469,15 +499,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Mon, 13 Jan 2020 23:16:20 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Location:
-      - /rack_role/88d2fba0-22df-4ac9-b0ab-f911872415ef
+      - /rack_role/b233a04d-d453-4730-8f4d-c945948c8d3b
       Request-Id:
-      - ZMzixSTyQrwI
+      - jWSWJb/hD0m1
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - ZMzixSTyQrwI
+      - jWSWJb/hD0m1
     status: 303 See Other
     code: 303
     duration: ""
@@ -491,10 +521,10 @@ interactions:
       - http://10.51.54.42:5000/rack_role
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/rack_role/88d2fba0-22df-4ac9-b0ab-f911872415ef
+    url: http://10.51.54.42:5000/rack_role/b233a04d-d453-4730-8f4d-c945948c8d3b
     method: GET
   response:
-    body: '{"created":"2020-01-13T23:16:20.906751Z","id":"88d2fba0-22df-4ac9-b0ab-f911872415ef","name":"kToauJTemcomWdudOSSYtCMDb","rack_size":60,"updated":"2020-01-13T23:16:20.906751Z"}'
+    body: '{"created":"2020-01-26T19:04:26.096897Z","id":"b233a04d-d453-4730-8f4d-c945948c8d3b","name":"PsSRIniTNebDKOEpDnzQrZASj","rack_size":60,"updated":"2020-01-26T19:04:26.096897Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -503,21 +533,21 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:20 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Request-Id:
-      - RVTp64kkvTjk
+      - eR+HhloicFFn
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - RVTp64kkvTjk
+      - eR+HhloicFFn
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"build_id":"68147506-b332-4471-8ec7-525680545366","datacenter_room_id":"724a6c54-9676-4169-8475-728866852b43","name":"bcSuZzwrjrForanmnlyUVpcsq","phase":"integration","rack_role_id":"88d2fba0-22df-4ac9-b0ab-f911872415ef"}
+      {"build_id":"7d2b96d4-3b2a-4a24-9fb9-fbfddf35dcc9","datacenter_room_id":"89ce0266-20fe-4136-a772-e2d9ace8d956","name":"RjWeunugnyPEEqdAfhxXBwAJK","phase":"integration","rack_role_id":"b233a04d-d453-4730-8f4d-c945948c8d3b"}
     form: {}
     headers:
       Content-Type:
@@ -534,15 +564,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Mon, 13 Jan 2020 23:16:20 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Location:
-      - /rack/f5043389-7031-4ba1-84cc-05dbb71cecc7
+      - /rack/7aadeb89-bd00-4b44-8dba-79409603b38f
       Request-Id:
-      - 5J7QUqruVU4m
+      - Nv5/woVeg9zq
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - 5J7QUqruVU4m
+      - Nv5/woVeg9zq
     status: 303 See Other
     code: 303
     duration: ""
@@ -556,10 +586,10 @@ interactions:
       - http://10.51.54.42:5000/rack
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/rack/f5043389-7031-4ba1-84cc-05dbb71cecc7
+    url: http://10.51.54.42:5000/rack/7aadeb89-bd00-4b44-8dba-79409603b38f
     method: GET
   response:
-    body: '{"asset_tag":null,"build_id":"68147506-b332-4471-8ec7-525680545366","build_name":"oXtNiTcABrbXxQiTPGcxqqodP","created":"2020-01-13T23:16:20.949953Z","datacenter_room_alias":"oySHUJEZhDYJoZkRrWAiGdpkU","datacenter_room_id":"724a6c54-9676-4169-8475-728866852b43","full_rack_name":"FnhzTeQgWlNnEqlVtMgGBWNYs:bcSuZzwrjrForanmnlyUVpcsq","id":"f5043389-7031-4ba1-84cc-05dbb71cecc7","name":"bcSuZzwrjrForanmnlyUVpcsq","phase":"integration","rack_role_id":"88d2fba0-22df-4ac9-b0ab-f911872415ef","rack_role_name":"kToauJTemcomWdudOSSYtCMDb","serial_number":null,"updated":"2020-01-13T23:16:20.949953Z"}'
+    body: '{"asset_tag":null,"build_id":"7d2b96d4-3b2a-4a24-9fb9-fbfddf35dcc9","build_name":"JIrULNPxKPKZncyExKMfLfGcY","created":"2020-01-26T19:04:26.135631Z","datacenter_room_alias":"YZScFfGvMadGNUUBxvuztEhmc","datacenter_room_id":"89ce0266-20fe-4136-a772-e2d9ace8d956","full_rack_name":"zNHMvLDMgbkfUIPtAhglCOwTg:RjWeunugnyPEEqdAfhxXBwAJK","id":"7aadeb89-bd00-4b44-8dba-79409603b38f","name":"RjWeunugnyPEEqdAfhxXBwAJK","phase":"integration","rack_role_id":"b233a04d-d453-4730-8f4d-c945948c8d3b","rack_role_name":"PsSRIniTNebDKOEpDnzQrZASj","serial_number":null,"updated":"2020-01-26T19:04:26.135631Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -568,17 +598,17 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:20 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Location:
-      - /rack/f5043389-7031-4ba1-84cc-05dbb71cecc7
+      - /rack/7aadeb89-bd00-4b44-8dba-79409603b38f
       Request-Id:
-      - w+1Ij7dSKh0H
+      - FTeBZkTY7ffr
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - w+1Ij7dSKh0H
+      - FTeBZkTY7ffr
     status: 200 OK
     code: 200
     duration: ""
@@ -588,10 +618,10 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/rack_role/88d2fba0-22df-4ac9-b0ab-f911872415ef
+    url: http://10.51.54.42:5000/rack_role/b233a04d-d453-4730-8f4d-c945948c8d3b
     method: GET
   response:
-    body: '{"created":"2020-01-13T23:16:20.906751Z","id":"88d2fba0-22df-4ac9-b0ab-f911872415ef","name":"kToauJTemcomWdudOSSYtCMDb","rack_size":60,"updated":"2020-01-13T23:16:20.906751Z"}'
+    body: '{"created":"2020-01-26T19:04:26.096897Z","id":"b233a04d-d453-4730-8f4d-c945948c8d3b","name":"PsSRIniTNebDKOEpDnzQrZASj","rack_size":60,"updated":"2020-01-26T19:04:26.096897Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -600,15 +630,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:20 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Request-Id:
-      - oYPw034nEKg6
+      - wMK/SVi78W5e
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - oYPw034nEKg6
+      - wMK/SVi78W5e
     status: 200 OK
     code: 200
     duration: ""
@@ -618,7 +648,7 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/rack/f5043389-7031-4ba1-84cc-05dbb71cecc7/layout
+    url: http://10.51.54.42:5000/rack/7aadeb89-bd00-4b44-8dba-79409603b38f/layout
     method: GET
   response:
     body: '[]'
@@ -630,23 +660,23 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:21 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Location:
-      - /rack/f5043389-7031-4ba1-84cc-05dbb71cecc7/layout
+      - /rack/7aadeb89-bd00-4b44-8dba-79409603b38f/layout
       Request-Id:
-      - ucRRYL8GvGUp
+      - Myw9FZancUab
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - ucRRYL8GvGUp
+      - Myw9FZancUab
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"hardware_product_id":"bb2996d4-b990-41f4-b073-2445969bea97","rack_id":"f5043389-7031-4ba1-84cc-05dbb71cecc7","rack_unit_start":1}
+      {"hardware_product_id":"6621614d-ad3d-42f7-8a6d-3cb94d8bd76e","rack_id":"7aadeb89-bd00-4b44-8dba-79409603b38f","rack_unit_start":1}
     form: {}
     headers:
       Content-Type:
@@ -663,15 +693,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Mon, 13 Jan 2020 23:16:21 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Location:
-      - /layout/f55efb0e-1e71-42ac-a23d-0a1427fe33f9
+      - /layout/f34b1733-0339-41af-9fb1-f6dee2bfcc04
       Request-Id:
-      - 42475ZZGazrG
+      - vYSpt3CKfsF0
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - 42475ZZGazrG
+      - vYSpt3CKfsF0
     status: 303 See Other
     code: 303
     duration: ""
@@ -685,10 +715,10 @@ interactions:
       - http://10.51.54.42:5000/layout
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/layout/f55efb0e-1e71-42ac-a23d-0a1427fe33f9
+    url: http://10.51.54.42:5000/layout/f34b1733-0339-41af-9fb1-f6dee2bfcc04
     method: GET
   response:
-    body: '{"created":"2020-01-13T23:16:21.063123Z","hardware_product_id":"bb2996d4-b990-41f4-b073-2445969bea97","id":"f55efb0e-1e71-42ac-a23d-0a1427fe33f9","rack_id":"f5043389-7031-4ba1-84cc-05dbb71cecc7","rack_name":"FnhzTeQgWlNnEqlVtMgGBWNYs:bcSuZzwrjrForanmnlyUVpcsq","rack_unit_size":2,"rack_unit_start":1,"sku":"RcDuMOWzWSOrhAzFErsMTSMko","updated":"2020-01-13T23:16:21.063123Z"}'
+    body: '{"created":"2020-01-26T19:04:26.241889Z","hardware_product_id":"6621614d-ad3d-42f7-8a6d-3cb94d8bd76e","id":"f34b1733-0339-41af-9fb1-f6dee2bfcc04","rack_id":"7aadeb89-bd00-4b44-8dba-79409603b38f","rack_name":"zNHMvLDMgbkfUIPtAhglCOwTg:RjWeunugnyPEEqdAfhxXBwAJK","rack_unit_size":1,"rack_unit_start":1,"sku":"FxCjKnuMmPTawRhYMJmKDWwrN","updated":"2020-01-26T19:04:26.241889Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -697,23 +727,23 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:21 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Location:
-      - /layout/f55efb0e-1e71-42ac-a23d-0a1427fe33f9
+      - /layout/f34b1733-0339-41af-9fb1-f6dee2bfcc04
       Request-Id:
-      - l5BKgRiZFSBP
+      - +sxvXTymWGlW
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - l5BKgRiZFSBP
+      - +sxvXTymWGlW
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"hardware_product_id":"aec8b534-e365-4ea1-b297-e0cc77247671","rack_id":"f5043389-7031-4ba1-84cc-05dbb71cecc7","rack_unit_start":3}
+      {"hardware_product_id":"2eca6269-a424-45f2-a3a9-a9913b8976ba","rack_id":"7aadeb89-bd00-4b44-8dba-79409603b38f","rack_unit_start":2}
     form: {}
     headers:
       Content-Type:
@@ -730,15 +760,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Mon, 13 Jan 2020 23:16:21 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Location:
-      - /layout/56a6bd3e-ea15-48c3-8ab5-f52748479f55
+      - /layout/2a3ef5b9-c936-478e-9e66-c097a7e16405
       Request-Id:
-      - NOCco2+iXrPN
+      - /ZDuM2OHa/nS
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - NOCco2+iXrPN
+      - /ZDuM2OHa/nS
     status: 303 See Other
     code: 303
     duration: ""
@@ -752,10 +782,10 @@ interactions:
       - http://10.51.54.42:5000/layout
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/layout/56a6bd3e-ea15-48c3-8ab5-f52748479f55
+    url: http://10.51.54.42:5000/layout/2a3ef5b9-c936-478e-9e66-c097a7e16405
     method: GET
   response:
-    body: '{"created":"2020-01-13T23:16:21.129139Z","hardware_product_id":"aec8b534-e365-4ea1-b297-e0cc77247671","id":"56a6bd3e-ea15-48c3-8ab5-f52748479f55","rack_id":"f5043389-7031-4ba1-84cc-05dbb71cecc7","rack_name":"FnhzTeQgWlNnEqlVtMgGBWNYs:bcSuZzwrjrForanmnlyUVpcsq","rack_unit_size":1,"rack_unit_start":3,"sku":"UqTmNGrfLtSTWvblmGqUEjIqq","updated":"2020-01-13T23:16:21.129139Z"}'
+    body: '{"created":"2020-01-26T19:04:26.303297Z","hardware_product_id":"2eca6269-a424-45f2-a3a9-a9913b8976ba","id":"2a3ef5b9-c936-478e-9e66-c097a7e16405","rack_id":"7aadeb89-bd00-4b44-8dba-79409603b38f","rack_name":"zNHMvLDMgbkfUIPtAhglCOwTg:RjWeunugnyPEEqdAfhxXBwAJK","rack_unit_size":2,"rack_unit_start":2,"sku":"xYxLsvSQYDsWVAxNTrUcxHIgL","updated":"2020-01-26T19:04:26.303297Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -764,17 +794,17 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:21 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Location:
-      - /layout/56a6bd3e-ea15-48c3-8ab5-f52748479f55
+      - /layout/2a3ef5b9-c936-478e-9e66-c097a7e16405
       Request-Id:
-      - QXNsOP8yGRXc
+      - n0uOdMchEnes
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - QXNsOP8yGRXc
+      - n0uOdMchEnes
     status: 200 OK
     code: 200
     duration: ""
@@ -784,10 +814,10 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/rack/f5043389-7031-4ba1-84cc-05dbb71cecc7/layout
+    url: http://10.51.54.42:5000/rack/7aadeb89-bd00-4b44-8dba-79409603b38f/layout
     method: GET
   response:
-    body: '[{"created":"2020-01-13T23:16:21.063123Z","hardware_product_id":"bb2996d4-b990-41f4-b073-2445969bea97","id":"f55efb0e-1e71-42ac-a23d-0a1427fe33f9","rack_id":"f5043389-7031-4ba1-84cc-05dbb71cecc7","rack_name":"FnhzTeQgWlNnEqlVtMgGBWNYs:bcSuZzwrjrForanmnlyUVpcsq","rack_unit_size":2,"rack_unit_start":1,"sku":"RcDuMOWzWSOrhAzFErsMTSMko","updated":"2020-01-13T23:16:21.063123Z"},{"created":"2020-01-13T23:16:21.129139Z","hardware_product_id":"aec8b534-e365-4ea1-b297-e0cc77247671","id":"56a6bd3e-ea15-48c3-8ab5-f52748479f55","rack_id":"f5043389-7031-4ba1-84cc-05dbb71cecc7","rack_name":"FnhzTeQgWlNnEqlVtMgGBWNYs:bcSuZzwrjrForanmnlyUVpcsq","rack_unit_size":1,"rack_unit_start":3,"sku":"UqTmNGrfLtSTWvblmGqUEjIqq","updated":"2020-01-13T23:16:21.129139Z"}]'
+    body: '[{"created":"2020-01-26T19:04:26.241889Z","hardware_product_id":"6621614d-ad3d-42f7-8a6d-3cb94d8bd76e","id":"f34b1733-0339-41af-9fb1-f6dee2bfcc04","rack_id":"7aadeb89-bd00-4b44-8dba-79409603b38f","rack_name":"zNHMvLDMgbkfUIPtAhglCOwTg:RjWeunugnyPEEqdAfhxXBwAJK","rack_unit_size":1,"rack_unit_start":1,"sku":"FxCjKnuMmPTawRhYMJmKDWwrN","updated":"2020-01-26T19:04:26.241889Z"},{"created":"2020-01-26T19:04:26.303297Z","hardware_product_id":"2eca6269-a424-45f2-a3a9-a9913b8976ba","id":"2a3ef5b9-c936-478e-9e66-c097a7e16405","rack_id":"7aadeb89-bd00-4b44-8dba-79409603b38f","rack_name":"zNHMvLDMgbkfUIPtAhglCOwTg:RjWeunugnyPEEqdAfhxXBwAJK","rack_unit_size":2,"rack_unit_start":2,"sku":"xYxLsvSQYDsWVAxNTrUcxHIgL","updated":"2020-01-26T19:04:26.303297Z"}]'
     headers:
       Cache-Control:
       - no-cache
@@ -796,30 +826,30 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:21 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Location:
-      - /rack/f5043389-7031-4ba1-84cc-05dbb71cecc7/layout
+      - /rack/7aadeb89-bd00-4b44-8dba-79409603b38f/layout
       Request-Id:
-      - M1EmEesZ8HxZ
+      - aIHciUSFEWpz
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - M1EmEesZ8HxZ
+      - aIHciUSFEWpz
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      [{"serial_number":"AAAAAA","sku":"UqTmNGrfLtSTWvblmGqUEjIqq"}]
+      [{"serial_number":"AAAAAA","sku":"xYxLsvSQYDsWVAxNTrUcxHIgL"}]
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/build/68147506-b332-4471-8ec7-525680545366/device
+    url: http://10.51.54.42:5000/build/7d2b96d4-3b2a-4a24-9fb9-fbfddf35dcc9/device
     method: POST
   response:
     body: ""
@@ -827,13 +857,13 @@ interactions:
       Cache-Control:
       - no-cache
       Date:
-      - Mon, 13 Jan 2020 23:16:21 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Request-Id:
-      - apRjjLbi3+yK
+      - KD8nVSooyjIi
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - apRjjLbi3+yK
+      - KD8nVSooyjIi
     status: 204 No Content
     code: 204
     duration: ""
@@ -846,7 +876,7 @@ interactions:
     url: http://10.51.54.42:5000/device/AAAAAA
     method: GET
   response:
-    body: '{"asset_tag":null,"build_id":"68147506-b332-4471-8ec7-525680545366","build_name":"oXtNiTcABrbXxQiTPGcxqqodP","created":"2019-10-31T19:42:47.273705Z","disks":[],"hardware_product_id":"aec8b534-e365-4ea1-b297-e0cc77247671","health":"unknown","hostname":null,"id":"ca19120e-4bda-4375-bf35-bda588d4d152","last_seen":null,"latest_report":null,"links":[],"location":null,"nics":[],"phase":"integration","serial_number":"AAAAAA","sku":"UqTmNGrfLtSTWvblmGqUEjIqq","system_uuid":null,"updated":"2020-01-13T23:16:21.218246Z","uptime_since":null,"validated":null}'
+    body: '{"asset_tag":null,"build_id":"7d2b96d4-3b2a-4a24-9fb9-fbfddf35dcc9","build_name":"JIrULNPxKPKZncyExKMfLfGcY","created":"2020-01-26T19:04:26.382355Z","disks":[],"hardware_product_id":"2eca6269-a424-45f2-a3a9-a9913b8976ba","health":"unknown","hostname":null,"id":"dd559c03-8901-4250-9946-0cdcf00d953c","last_seen":null,"latest_report":null,"links":[],"location":null,"nics":[],"phase":"integration","serial_number":"AAAAAA","sku":"xYxLsvSQYDsWVAxNTrUcxHIgL","system_uuid":null,"updated":"2020-01-26T19:04:26.382355Z","uptime_since":null,"validated":null}'
     headers:
       Cache-Control:
       - no-cache
@@ -855,19 +885,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:21 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Etag:
-      - '"ca1a0b4e95386561b24b5096713793f7"'
+      - '"d1e25cc0b1cb2f7ec1380a3ce54e43f9"'
       Location:
-      - /device/ca19120e-4bda-4375-bf35-bda588d4d152
+      - /device/dd559c03-8901-4250-9946-0cdcf00d953c
       Request-Id:
-      - M3KMMsMKldoe
+      - 8Ks0NjxXOuJd
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - M3KMMsMKldoe
+      - 8Ks0NjxXOuJd
     status: 200 OK
     code: 200
     duration: ""
@@ -880,7 +910,7 @@ interactions:
       - application/json
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/device/ca19120e-4bda-4375-bf35-bda588d4d152/settings/test_setting
+    url: http://10.51.54.42:5000/device/dd559c03-8901-4250-9946-0cdcf00d953c/settings/test_setting
     method: POST
   response:
     body: ""
@@ -888,15 +918,15 @@ interactions:
       Cache-Control:
       - no-cache
       Date:
-      - Mon, 13 Jan 2020 23:16:21 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Location:
-      - /device/ca19120e-4bda-4375-bf35-bda588d4d152
+      - /device/dd559c03-8901-4250-9946-0cdcf00d953c
       Request-Id:
-      - h9zEp/QRHON4
+      - aNAaTiQktlz2
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - h9zEp/QRHON4
+      - aNAaTiQktlz2
     status: 204 No Content
     code: 204
     duration: ""
@@ -906,10 +936,10 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/device/ca19120e-4bda-4375-bf35-bda588d4d152
+    url: http://10.51.54.42:5000/device/dd559c03-8901-4250-9946-0cdcf00d953c
     method: GET
   response:
-    body: '{"asset_tag":null,"build_id":"68147506-b332-4471-8ec7-525680545366","build_name":"oXtNiTcABrbXxQiTPGcxqqodP","created":"2019-10-31T19:42:47.273705Z","disks":[],"hardware_product_id":"aec8b534-e365-4ea1-b297-e0cc77247671","health":"unknown","hostname":null,"id":"ca19120e-4bda-4375-bf35-bda588d4d152","last_seen":null,"latest_report":null,"links":[],"location":null,"nics":[],"phase":"integration","serial_number":"AAAAAA","sku":"UqTmNGrfLtSTWvblmGqUEjIqq","system_uuid":null,"updated":"2020-01-13T23:16:21.218246Z","uptime_since":null,"validated":null}'
+    body: '{"asset_tag":null,"build_id":"7d2b96d4-3b2a-4a24-9fb9-fbfddf35dcc9","build_name":"JIrULNPxKPKZncyExKMfLfGcY","created":"2020-01-26T19:04:26.382355Z","disks":[],"hardware_product_id":"2eca6269-a424-45f2-a3a9-a9913b8976ba","health":"unknown","hostname":null,"id":"dd559c03-8901-4250-9946-0cdcf00d953c","last_seen":null,"latest_report":null,"links":[],"location":null,"nics":[],"phase":"integration","serial_number":"AAAAAA","sku":"xYxLsvSQYDsWVAxNTrUcxHIgL","system_uuid":null,"updated":"2020-01-26T19:04:26.382355Z","uptime_since":null,"validated":null}'
     headers:
       Cache-Control:
       - no-cache
@@ -918,19 +948,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:21 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Etag:
-      - '"ca1a0b4e95386561b24b5096713793f7"'
+      - '"d1e25cc0b1cb2f7ec1380a3ce54e43f9"'
       Location:
-      - /device/ca19120e-4bda-4375-bf35-bda588d4d152
+      - /device/dd559c03-8901-4250-9946-0cdcf00d953c
       Request-Id:
-      - si8HlJat7+kk
+      - o5X/t1oHHoTS
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - si8HlJat7+kk
+      - o5X/t1oHHoTS
     status: 200 OK
     code: 200
     duration: ""
@@ -940,7 +970,7 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/device/ca19120e-4bda-4375-bf35-bda588d4d152/settings/test_setting
+    url: http://10.51.54.42:5000/device/dd559c03-8901-4250-9946-0cdcf00d953c/settings/test_setting
     method: GET
   response:
     body: '{"test_setting":"foo"}'
@@ -952,17 +982,17 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:21 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Location:
-      - /device/ca19120e-4bda-4375-bf35-bda588d4d152
+      - /device/dd559c03-8901-4250-9946-0cdcf00d953c
       Request-Id:
-      - jfMOxRCIp1ka
+      - 6AlCjMxEEJUl
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - jfMOxRCIp1ka
+      - 6AlCjMxEEJUl
     status: 200 OK
     code: 200
     duration: ""
@@ -972,7 +1002,7 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/device/ca19120e-4bda-4375-bf35-bda588d4d152/settings
+    url: http://10.51.54.42:5000/device/dd559c03-8901-4250-9946-0cdcf00d953c/settings
     method: GET
   response:
     body: '{"test_setting":"foo"}'
@@ -984,17 +1014,17 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:21 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Location:
-      - /device/ca19120e-4bda-4375-bf35-bda588d4d152
+      - /device/dd559c03-8901-4250-9946-0cdcf00d953c
       Request-Id:
-      - 3wKOnSaqDqB0
+      - w5Jq5HsZI27f
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - 3wKOnSaqDqB0
+      - w5Jq5HsZI27f
     status: 200 OK
     code: 200
     duration: ""
@@ -1004,7 +1034,7 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/device/ca19120e-4bda-4375-bf35-bda588d4d152/settings
+    url: http://10.51.54.42:5000/device/dd559c03-8901-4250-9946-0cdcf00d953c/settings
     method: GET
   response:
     body: '{"test_setting":"foo"}'
@@ -1016,30 +1046,30 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:21 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Location:
-      - /device/ca19120e-4bda-4375-bf35-bda588d4d152
+      - /device/dd559c03-8901-4250-9946-0cdcf00d953c
       Request-Id:
-      - /oQhQByWeetQ
+      - T7LUXKGp20ej
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - /oQhQByWeetQ
+      - T7LUXKGp20ej
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      [{"device_id":"ca19120e-4bda-4375-bf35-bda588d4d152","rack_unit_start":1}]
+      [{"device_id":"dd559c03-8901-4250-9946-0cdcf00d953c","rack_unit_start":1}]
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/rack/f5043389-7031-4ba1-84cc-05dbb71cecc7/assignment
+    url: http://10.51.54.42:5000/rack/7aadeb89-bd00-4b44-8dba-79409603b38f/assignment
     method: POST
   response:
     body: ""
@@ -1049,15 +1079,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Mon, 13 Jan 2020 23:16:21 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Location:
-      - /rack/f5043389-7031-4ba1-84cc-05dbb71cecc7/assignment
+      - /rack/7aadeb89-bd00-4b44-8dba-79409603b38f/assignment
       Request-Id:
-      - Oiy+7nC4HNfe
+      - gAE5NDAxwcgr
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - Oiy+7nC4HNfe
+      - gAE5NDAxwcgr
     status: 303 See Other
     code: 303
     duration: ""
@@ -1068,13 +1098,13 @@ interactions:
       Content-Type:
       - application/json
       Referer:
-      - http://10.51.54.42:5000/rack/f5043389-7031-4ba1-84cc-05dbb71cecc7/assignment
+      - http://10.51.54.42:5000/rack/7aadeb89-bd00-4b44-8dba-79409603b38f/assignment
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/rack/f5043389-7031-4ba1-84cc-05dbb71cecc7/assignment
+    url: http://10.51.54.42:5000/rack/7aadeb89-bd00-4b44-8dba-79409603b38f/assignment
     method: GET
   response:
-    body: '[{"device_asset_tag":null,"device_id":"ca19120e-4bda-4375-bf35-bda588d4d152","hardware_product_name":"DkDGSlKRDwYsrZzQLXplUuRFb","rack_unit_size":2,"rack_unit_start":1,"sku":"RcDuMOWzWSOrhAzFErsMTSMko"},{"device_asset_tag":null,"device_id":null,"hardware_product_name":"jTVlTCMbVYzTzKzcsknuluMWJ","rack_unit_size":1,"rack_unit_start":3,"sku":"UqTmNGrfLtSTWvblmGqUEjIqq"}]'
+    body: '[{"device_asset_tag":null,"device_id":"dd559c03-8901-4250-9946-0cdcf00d953c","hardware_product_name":"ZLepZJcnMPSuCGgjCKATuzdbm","rack_unit_size":1,"rack_unit_start":1,"sku":"FxCjKnuMmPTawRhYMJmKDWwrN"},{"device_asset_tag":null,"device_id":null,"hardware_product_name":"KPHacrRjdKTXHRQkYFizhiXiJ","rack_unit_size":2,"rack_unit_start":2,"sku":"xYxLsvSQYDsWVAxNTrUcxHIgL"}]'
     headers:
       Cache-Control:
       - no-cache
@@ -1083,17 +1113,17 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:21 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Location:
-      - /rack/f5043389-7031-4ba1-84cc-05dbb71cecc7/assignment
+      - /rack/7aadeb89-bd00-4b44-8dba-79409603b38f/assignment
       Request-Id:
-      - pHVdek1BGP1A
+      - Ja5w7V8WG7qq
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - pHVdek1BGP1A
+      - Ja5w7V8WG7qq
     status: 200 OK
     code: 200
     duration: ""
@@ -1103,10 +1133,10 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/rack/f5043389-7031-4ba1-84cc-05dbb71cecc7/assignment
+    url: http://10.51.54.42:5000/rack/7aadeb89-bd00-4b44-8dba-79409603b38f/assignment
     method: GET
   response:
-    body: '[{"device_asset_tag":null,"device_id":"ca19120e-4bda-4375-bf35-bda588d4d152","hardware_product_name":"DkDGSlKRDwYsrZzQLXplUuRFb","rack_unit_size":2,"rack_unit_start":1,"sku":"RcDuMOWzWSOrhAzFErsMTSMko"},{"device_asset_tag":null,"device_id":null,"hardware_product_name":"jTVlTCMbVYzTzKzcsknuluMWJ","rack_unit_size":1,"rack_unit_start":3,"sku":"UqTmNGrfLtSTWvblmGqUEjIqq"}]'
+    body: '[{"device_asset_tag":null,"device_id":"dd559c03-8901-4250-9946-0cdcf00d953c","hardware_product_name":"ZLepZJcnMPSuCGgjCKATuzdbm","rack_unit_size":1,"rack_unit_start":1,"sku":"FxCjKnuMmPTawRhYMJmKDWwrN"},{"device_asset_tag":null,"device_id":null,"hardware_product_name":"KPHacrRjdKTXHRQkYFizhiXiJ","rack_unit_size":2,"rack_unit_start":2,"sku":"xYxLsvSQYDsWVAxNTrUcxHIgL"}]'
     headers:
       Cache-Control:
       - no-cache
@@ -1115,17 +1145,17 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:21 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Location:
-      - /rack/f5043389-7031-4ba1-84cc-05dbb71cecc7/assignment
+      - /rack/7aadeb89-bd00-4b44-8dba-79409603b38f/assignment
       Request-Id:
-      - zuvdguZxpXQ6
+      - 16FVyvYMuV+p
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - zuvdguZxpXQ6
+      - 16FVyvYMuV+p
     status: 200 OK
     code: 200
     duration: ""
@@ -1135,10 +1165,10 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/device/ca19120e-4bda-4375-bf35-bda588d4d152/location
+    url: http://10.51.54.42:5000/device/dd559c03-8901-4250-9946-0cdcf00d953c/location
     method: GET
   response:
-    body: '{"az":"VJiGAAwpXmKZsuVUEGZCfEMcj","datacenter_room":"oySHUJEZhDYJoZkRrWAiGdpkU","rack":"FnhzTeQgWlNnEqlVtMgGBWNYs:bcSuZzwrjrForanmnlyUVpcsq","rack_unit_start":1,"target_hardware_product":{"alias":"yerxeoFNWksgibkdHLxDxllXg","hardware_vendor_id":"97c61378-695e-4966-8006-90531f1717c5","id":"bb2996d4-b990-41f4-b073-2445969bea97","name":"DkDGSlKRDwYsrZzQLXplUuRFb","sku":"RcDuMOWzWSOrhAzFErsMTSMko"}}'
+    body: '{"az":"rSHTRbXlBtZUUPZowzIXvGTtU","datacenter_room":"YZScFfGvMadGNUUBxvuztEhmc","rack":"zNHMvLDMgbkfUIPtAhglCOwTg:RjWeunugnyPEEqdAfhxXBwAJK","rack_unit_start":1,"target_hardware_product":{"alias":"fZUdZGfPTpNuoaETCoAXHzHdh","hardware_vendor_id":"713e2342-ed15-409d-a07c-bbca41941d92","id":"6621614d-ad3d-42f7-8a6d-3cb94d8bd76e","name":"ZLepZJcnMPSuCGgjCKATuzdbm","sku":"FxCjKnuMmPTawRhYMJmKDWwrN"}}'
     headers:
       Cache-Control:
       - no-cache
@@ -1147,17 +1177,17 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:21 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Location:
-      - /device/ca19120e-4bda-4375-bf35-bda588d4d152
+      - /device/dd559c03-8901-4250-9946-0cdcf00d953c
       Request-Id:
-      - oPzTN2F/9JvX
+      - O41e1xirQEXc
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - oPzTN2F/9JvX
+      - O41e1xirQEXc
     status: 200 OK
     code: 200
     duration: ""
@@ -1167,10 +1197,10 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/device/ca19120e-4bda-4375-bf35-bda588d4d152
+    url: http://10.51.54.42:5000/device/dd559c03-8901-4250-9946-0cdcf00d953c
     method: GET
   response:
-    body: '{"asset_tag":null,"build_id":"68147506-b332-4471-8ec7-525680545366","build_name":"oXtNiTcABrbXxQiTPGcxqqodP","created":"2019-10-31T19:42:47.273705Z","disks":[],"hardware_product_id":"aec8b534-e365-4ea1-b297-e0cc77247671","health":"unknown","hostname":null,"id":"ca19120e-4bda-4375-bf35-bda588d4d152","last_seen":null,"latest_report":null,"links":[],"location":{"az":"VJiGAAwpXmKZsuVUEGZCfEMcj","datacenter_room":"oySHUJEZhDYJoZkRrWAiGdpkU","rack":"FnhzTeQgWlNnEqlVtMgGBWNYs:bcSuZzwrjrForanmnlyUVpcsq","rack_unit_start":1,"target_hardware_product":{"alias":"yerxeoFNWksgibkdHLxDxllXg","hardware_vendor_id":"97c61378-695e-4966-8006-90531f1717c5","id":"bb2996d4-b990-41f4-b073-2445969bea97","name":"DkDGSlKRDwYsrZzQLXplUuRFb","sku":"RcDuMOWzWSOrhAzFErsMTSMko"}},"nics":[],"phase":"integration","serial_number":"AAAAAA","sku":"UqTmNGrfLtSTWvblmGqUEjIqq","system_uuid":null,"updated":"2020-01-13T23:16:21.218246Z","uptime_since":null,"validated":null}'
+    body: '{"asset_tag":null,"build_id":"7d2b96d4-3b2a-4a24-9fb9-fbfddf35dcc9","build_name":"JIrULNPxKPKZncyExKMfLfGcY","created":"2020-01-26T19:04:26.382355Z","disks":[],"hardware_product_id":"2eca6269-a424-45f2-a3a9-a9913b8976ba","health":"unknown","hostname":null,"id":"dd559c03-8901-4250-9946-0cdcf00d953c","last_seen":null,"latest_report":null,"links":[],"location":{"az":"rSHTRbXlBtZUUPZowzIXvGTtU","datacenter_room":"YZScFfGvMadGNUUBxvuztEhmc","rack":"zNHMvLDMgbkfUIPtAhglCOwTg:RjWeunugnyPEEqdAfhxXBwAJK","rack_unit_start":1,"target_hardware_product":{"alias":"fZUdZGfPTpNuoaETCoAXHzHdh","hardware_vendor_id":"713e2342-ed15-409d-a07c-bbca41941d92","id":"6621614d-ad3d-42f7-8a6d-3cb94d8bd76e","name":"ZLepZJcnMPSuCGgjCKATuzdbm","sku":"FxCjKnuMmPTawRhYMJmKDWwrN"}},"nics":[],"phase":"integration","serial_number":"AAAAAA","sku":"xYxLsvSQYDsWVAxNTrUcxHIgL","system_uuid":null,"updated":"2020-01-26T19:04:26.382355Z","uptime_since":null,"validated":null}'
     headers:
       Cache-Control:
       - no-cache
@@ -1179,19 +1209,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:21 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Etag:
-      - '"ca1a0b4e95386561b24b5096713793f7"'
+      - '"d1e25cc0b1cb2f7ec1380a3ce54e43f9"'
       Location:
-      - /device/ca19120e-4bda-4375-bf35-bda588d4d152
+      - /device/dd559c03-8901-4250-9946-0cdcf00d953c
       Request-Id:
-      - xVGoiYV9u27h
+      - MlbKJnoDxIFK
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - xVGoiYV9u27h
+      - MlbKJnoDxIFK
     status: 200 OK
     code: 200
     duration: ""
@@ -1201,10 +1231,10 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/rack/FnhzTeQgWlNnEqlVtMgGBWNYs:bcSuZzwrjrForanmnlyUVpcsq
+    url: http://10.51.54.42:5000/rack/zNHMvLDMgbkfUIPtAhglCOwTg:RjWeunugnyPEEqdAfhxXBwAJK
     method: GET
   response:
-    body: '{"asset_tag":null,"build_id":"68147506-b332-4471-8ec7-525680545366","build_name":"oXtNiTcABrbXxQiTPGcxqqodP","created":"2020-01-13T23:16:20.949953Z","datacenter_room_alias":"oySHUJEZhDYJoZkRrWAiGdpkU","datacenter_room_id":"724a6c54-9676-4169-8475-728866852b43","full_rack_name":"FnhzTeQgWlNnEqlVtMgGBWNYs:bcSuZzwrjrForanmnlyUVpcsq","id":"f5043389-7031-4ba1-84cc-05dbb71cecc7","name":"bcSuZzwrjrForanmnlyUVpcsq","phase":"integration","rack_role_id":"88d2fba0-22df-4ac9-b0ab-f911872415ef","rack_role_name":"kToauJTemcomWdudOSSYtCMDb","serial_number":null,"updated":"2020-01-13T23:16:20.949953Z"}'
+    body: '{"asset_tag":null,"build_id":"7d2b96d4-3b2a-4a24-9fb9-fbfddf35dcc9","build_name":"JIrULNPxKPKZncyExKMfLfGcY","created":"2020-01-26T19:04:26.135631Z","datacenter_room_alias":"YZScFfGvMadGNUUBxvuztEhmc","datacenter_room_id":"89ce0266-20fe-4136-a772-e2d9ace8d956","full_rack_name":"zNHMvLDMgbkfUIPtAhglCOwTg:RjWeunugnyPEEqdAfhxXBwAJK","id":"7aadeb89-bd00-4b44-8dba-79409603b38f","name":"RjWeunugnyPEEqdAfhxXBwAJK","phase":"integration","rack_role_id":"b233a04d-d453-4730-8f4d-c945948c8d3b","rack_role_name":"PsSRIniTNebDKOEpDnzQrZASj","serial_number":null,"updated":"2020-01-26T19:04:26.135631Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -1213,17 +1243,17 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:21 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Location:
-      - /rack/f5043389-7031-4ba1-84cc-05dbb71cecc7
+      - /rack/7aadeb89-bd00-4b44-8dba-79409603b38f
       Request-Id:
-      - rWF3P2vruCGQ
+      - rV6q113SMqcf
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - rWF3P2vruCGQ
+      - rV6q113SMqcf
     status: 200 OK
     code: 200
     duration: ""
@@ -1233,10 +1263,10 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/rack_role/88d2fba0-22df-4ac9-b0ab-f911872415ef
+    url: http://10.51.54.42:5000/rack_role/b233a04d-d453-4730-8f4d-c945948c8d3b
     method: GET
   response:
-    body: '{"created":"2020-01-13T23:16:20.906751Z","id":"88d2fba0-22df-4ac9-b0ab-f911872415ef","name":"kToauJTemcomWdudOSSYtCMDb","rack_size":60,"updated":"2020-01-13T23:16:20.906751Z"}'
+    body: '{"created":"2020-01-26T19:04:26.096897Z","id":"b233a04d-d453-4730-8f4d-c945948c8d3b","name":"PsSRIniTNebDKOEpDnzQrZASj","rack_size":60,"updated":"2020-01-26T19:04:26.096897Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -1245,15 +1275,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:21 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Request-Id:
-      - Ni6JDk01J5HI
+      - ZJ7qR3LYUcAi
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - Ni6JDk01J5HI
+      - ZJ7qR3LYUcAi
     status: 200 OK
     code: 200
     duration: ""
@@ -1263,10 +1293,10 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/room/724a6c54-9676-4169-8475-728866852b43
+    url: http://10.51.54.42:5000/room/89ce0266-20fe-4136-a772-e2d9ace8d956
     method: GET
   response:
-    body: '{"alias":"oySHUJEZhDYJoZkRrWAiGdpkU","az":"VJiGAAwpXmKZsuVUEGZCfEMcj","created":"2020-01-13T23:16:20.803937Z","datacenter_id":"5e509013-7894-4e0e-a9bb-3e71d9f402c9","id":"724a6c54-9676-4169-8475-728866852b43","updated":"2020-01-13T23:16:20.803937Z","vendor_name":"FnhzTeQgWlNnEqlVtMgGBWNYs"}'
+    body: '{"alias":"YZScFfGvMadGNUUBxvuztEhmc","az":"rSHTRbXlBtZUUPZowzIXvGTtU","created":"2020-01-26T19:04:26.008325Z","datacenter_id":"bc85ceef-2d58-45ae-a659-1b666f794795","id":"89ce0266-20fe-4136-a772-e2d9ace8d956","updated":"2020-01-26T19:04:26.008325Z","vendor_name":"zNHMvLDMgbkfUIPtAhglCOwTg"}'
     headers:
       Cache-Control:
       - no-cache
@@ -1275,17 +1305,17 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:21 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Location:
-      - /room/724a6c54-9676-4169-8475-728866852b43
+      - /room/89ce0266-20fe-4136-a772-e2d9ace8d956
       Request-Id:
-      - Q4P85sC22Ub3
+      - cJjqMBT/qTD4
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - Q4P85sC22Ub3
+      - cJjqMBT/qTD4
     status: 200 OK
     code: 200
     duration: ""
@@ -1295,10 +1325,10 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/rack_role/88d2fba0-22df-4ac9-b0ab-f911872415ef
+    url: http://10.51.54.42:5000/rack_role/b233a04d-d453-4730-8f4d-c945948c8d3b
     method: GET
   response:
-    body: '{"created":"2020-01-13T23:16:20.906751Z","id":"88d2fba0-22df-4ac9-b0ab-f911872415ef","name":"kToauJTemcomWdudOSSYtCMDb","rack_size":60,"updated":"2020-01-13T23:16:20.906751Z"}'
+    body: '{"created":"2020-01-26T19:04:26.096897Z","id":"b233a04d-d453-4730-8f4d-c945948c8d3b","name":"PsSRIniTNebDKOEpDnzQrZASj","rack_size":60,"updated":"2020-01-26T19:04:26.096897Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -1307,15 +1337,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:21 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Request-Id:
-      - 2CtK2fuXam9r
+      - rFokMvOBy8qX
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - 2CtK2fuXam9r
+      - rFokMvOBy8qX
     status: 200 OK
     code: 200
     duration: ""
@@ -1325,10 +1355,10 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/hardware_product/aec8b534-e365-4ea1-b297-e0cc77247671
+    url: http://10.51.54.42:5000/hardware_product/2eca6269-a424-45f2-a3a9-a9913b8976ba
     method: GET
   response:
-    body: '{"alias":"VJyvwevrxySZAvrKjrbtbgYyq","bios_firmware":"VzYgMZEqAUNABMDwZRJiNIqZg","cpu_num":0,"cpu_type":"vbmXmDGagjdhfIHLKaKQejKrn","created":"2020-01-13T23:16:20.655148Z","dimms_num":0,"generation_name":null,"hardware_vendor_id":"97c61378-695e-4966-8006-90531f1717c5","hba_firmware":null,"id":"aec8b534-e365-4ea1-b297-e0cc77247671","legacy_product_name":null,"name":"jTVlTCMbVYzTzKzcsknuluMWJ","nics_num":0,"nvme_ssd_num":0,"nvme_ssd_size":null,"nvme_ssd_slots":null,"prefix":null,"psu_total":0,"purpose":"LARDMlEVwBkvfEhTEVHlHvigy","rack_unit_size":1,"raid_lun_num":0,"ram_total":0,"sas_hdd_num":0,"sas_hdd_size":null,"sas_hdd_slots":null,"sas_ssd_num":0,"sas_ssd_size":null,"sas_ssd_slots":null,"sata_hdd_num":0,"sata_hdd_size":null,"sata_hdd_slots":null,"sata_ssd_num":0,"sata_ssd_size":null,"sata_ssd_slots":null,"sku":"UqTmNGrfLtSTWvblmGqUEjIqq","specification":null,"updated":"2020-01-13T23:16:20.655148Z","usb_num":0,"validation_plan_id":"a30ab8b2-8a9e-4e51-8bb0-92862abd8b54"}'
+    body: '{"alias":"VgvjJOOnrRwUYxWQFOtemUQuQ","bios_firmware":"XqkAkCZYLvgRLvYqIrtHPFhVN","cpu_num":0,"cpu_type":"AjbeLNHApsBhqcpiSwSZtssQx","created":"2020-01-26T19:04:25.859308Z","dimms_num":0,"generation_name":null,"hardware_vendor_id":"713e2342-ed15-409d-a07c-bbca41941d92","hba_firmware":null,"id":"2eca6269-a424-45f2-a3a9-a9913b8976ba","legacy_product_name":null,"name":"KPHacrRjdKTXHRQkYFizhiXiJ","nics_num":0,"nvme_ssd_num":0,"nvme_ssd_size":null,"nvme_ssd_slots":null,"prefix":null,"psu_total":0,"purpose":"uNggImrxtZCFRXriVRahxKFvd","rack_unit_size":2,"raid_lun_num":0,"ram_total":0,"sas_hdd_num":0,"sas_hdd_size":null,"sas_hdd_slots":null,"sas_ssd_num":0,"sas_ssd_size":null,"sas_ssd_slots":null,"sata_hdd_num":0,"sata_hdd_size":null,"sata_hdd_slots":null,"sata_ssd_num":0,"sata_ssd_size":null,"sata_ssd_slots":null,"sku":"xYxLsvSQYDsWVAxNTrUcxHIgL","specification":null,"updated":"2020-01-26T19:04:25.859308Z","usb_num":0,"validation_plan_id":"a30ab8b2-8a9e-4e51-8bb0-92862abd8b54"}'
     headers:
       Cache-Control:
       - no-cache
@@ -1337,17 +1367,17 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:21 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Location:
-      - /hardware_product/aec8b534-e365-4ea1-b297-e0cc77247671
+      - /hardware_product/2eca6269-a424-45f2-a3a9-a9913b8976ba
       Request-Id:
-      - aNG5oKbpNs3S
+      - UwnKm3FJ1z+6
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - aNG5oKbpNs3S
+      - UwnKm3FJ1z+6
     status: 200 OK
     code: 200
     duration: ""
@@ -1357,7 +1387,7 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/device/ca19120e-4bda-4375-bf35-bda588d4d152/validation_state
+    url: http://10.51.54.42:5000/device/dd559c03-8901-4250-9946-0cdcf00d953c/validation_state
     method: GET
   response:
     body: '[]'
@@ -1369,17 +1399,17 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:21 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Location:
-      - /device/ca19120e-4bda-4375-bf35-bda588d4d152
+      - /device/dd559c03-8901-4250-9946-0cdcf00d953c
       Request-Id:
-      - rM9PDn46Xw9d
+      - Nue0rc9wjDHk
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - rM9PDn46Xw9d
+      - Nue0rc9wjDHk
     status: 200 OK
     code: 200
     duration: ""
@@ -1389,7 +1419,7 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/device/ca19120e-4bda-4375-bf35-bda588d4d152/validation_state
+    url: http://10.51.54.42:5000/device/dd559c03-8901-4250-9946-0cdcf00d953c/validation_state
     method: GET
   response:
     body: '[]'
@@ -1401,17 +1431,17 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:21 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Location:
-      - /device/ca19120e-4bda-4375-bf35-bda588d4d152
+      - /device/dd559c03-8901-4250-9946-0cdcf00d953c
       Request-Id:
-      - 7fsfkp8+mUUs
+      - ixZVfEKuJrJL
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - 7fsfkp8+mUUs
+      - ixZVfEKuJrJL
     status: 200 OK
     code: 200
     duration: ""
@@ -1421,10 +1451,10 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/device/ca19120e-4bda-4375-bf35-bda588d4d152/phase
+    url: http://10.51.54.42:5000/device/dd559c03-8901-4250-9946-0cdcf00d953c/phase
     method: GET
   response:
-    body: '{"id":"ca19120e-4bda-4375-bf35-bda588d4d152","phase":"integration"}'
+    body: '{"id":"dd559c03-8901-4250-9946-0cdcf00d953c","phase":"integration"}'
     headers:
       Cache-Control:
       - no-cache
@@ -1433,17 +1463,17 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:21 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Location:
-      - /device/ca19120e-4bda-4375-bf35-bda588d4d152
+      - /device/dd559c03-8901-4250-9946-0cdcf00d953c
       Request-Id:
-      - 4/OO/ILM3YD6
+      - JqWLVQaJY9Ux
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - 4/OO/ILM3YD6
+      - JqWLVQaJY9Ux
     status: 200 OK
     code: 200
     duration: ""
@@ -1453,7 +1483,7 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/device/ca19120e-4bda-4375-bf35-bda588d4d152/location
+    url: http://10.51.54.42:5000/device/dd559c03-8901-4250-9946-0cdcf00d953c/location
     method: DELETE
   response:
     body: ""
@@ -1461,15 +1491,15 @@ interactions:
       Cache-Control:
       - no-cache
       Date:
-      - Mon, 13 Jan 2020 23:16:21 GMT
+      - Sun, 26 Jan 2020 19:04:26 GMT
       Location:
-      - /device/ca19120e-4bda-4375-bf35-bda588d4d152
+      - /device/dd559c03-8901-4250-9946-0cdcf00d953c
       Request-Id:
-      - ubPtwLPCVU4T
+      - SPqYNyeA82gr
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - ubPtwLPCVU4T
+      - SPqYNyeA82gr
     status: 204 No Content
     code: 204
     duration: ""
@@ -1479,10 +1509,10 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/device/ca19120e-4bda-4375-bf35-bda588d4d152
+    url: http://10.51.54.42:5000/device/dd559c03-8901-4250-9946-0cdcf00d953c
     method: GET
   response:
-    body: '{"asset_tag":null,"build_id":"68147506-b332-4471-8ec7-525680545366","build_name":"oXtNiTcABrbXxQiTPGcxqqodP","created":"2019-10-31T19:42:47.273705Z","disks":[],"hardware_product_id":"aec8b534-e365-4ea1-b297-e0cc77247671","health":"unknown","hostname":null,"id":"ca19120e-4bda-4375-bf35-bda588d4d152","last_seen":null,"latest_report":null,"links":[],"location":null,"nics":[],"phase":"integration","serial_number":"AAAAAA","sku":"UqTmNGrfLtSTWvblmGqUEjIqq","system_uuid":null,"updated":"2020-01-13T23:16:21.218246Z","uptime_since":null,"validated":null}'
+    body: '{"asset_tag":null,"build_id":"7d2b96d4-3b2a-4a24-9fb9-fbfddf35dcc9","build_name":"JIrULNPxKPKZncyExKMfLfGcY","created":"2020-01-26T19:04:26.382355Z","disks":[],"hardware_product_id":"2eca6269-a424-45f2-a3a9-a9913b8976ba","health":"unknown","hostname":null,"id":"dd559c03-8901-4250-9946-0cdcf00d953c","last_seen":null,"latest_report":null,"links":[],"location":null,"nics":[],"phase":"integration","serial_number":"AAAAAA","sku":"xYxLsvSQYDsWVAxNTrUcxHIgL","system_uuid":null,"updated":"2020-01-26T19:04:26.382355Z","uptime_since":null,"validated":null}'
     headers:
       Cache-Control:
       - no-cache
@@ -1491,19 +1521,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:21 GMT
+      - Sun, 26 Jan 2020 19:04:27 GMT
       Etag:
-      - '"ca1a0b4e95386561b24b5096713793f7"'
+      - '"d1e25cc0b1cb2f7ec1380a3ce54e43f9"'
       Location:
-      - /device/ca19120e-4bda-4375-bf35-bda588d4d152
+      - /device/dd559c03-8901-4250-9946-0cdcf00d953c
       Request-Id:
-      - 1gvZG7x9/dhk
+      - Rix792kKn1nu
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - 1gvZG7x9/dhk
+      - Rix792kKn1nu
     status: 200 OK
     code: 200
     duration: ""
@@ -1513,10 +1543,10 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/rack/f5043389-7031-4ba1-84cc-05dbb71cecc7/layout
+    url: http://10.51.54.42:5000/rack/7aadeb89-bd00-4b44-8dba-79409603b38f/layout
     method: GET
   response:
-    body: '[{"created":"2020-01-13T23:16:21.063123Z","hardware_product_id":"bb2996d4-b990-41f4-b073-2445969bea97","id":"f55efb0e-1e71-42ac-a23d-0a1427fe33f9","rack_id":"f5043389-7031-4ba1-84cc-05dbb71cecc7","rack_name":"FnhzTeQgWlNnEqlVtMgGBWNYs:bcSuZzwrjrForanmnlyUVpcsq","rack_unit_size":2,"rack_unit_start":1,"sku":"RcDuMOWzWSOrhAzFErsMTSMko","updated":"2020-01-13T23:16:21.063123Z"},{"created":"2020-01-13T23:16:21.129139Z","hardware_product_id":"aec8b534-e365-4ea1-b297-e0cc77247671","id":"56a6bd3e-ea15-48c3-8ab5-f52748479f55","rack_id":"f5043389-7031-4ba1-84cc-05dbb71cecc7","rack_name":"FnhzTeQgWlNnEqlVtMgGBWNYs:bcSuZzwrjrForanmnlyUVpcsq","rack_unit_size":1,"rack_unit_start":3,"sku":"UqTmNGrfLtSTWvblmGqUEjIqq","updated":"2020-01-13T23:16:21.129139Z"}]'
+    body: '[{"created":"2020-01-26T19:04:26.241889Z","hardware_product_id":"6621614d-ad3d-42f7-8a6d-3cb94d8bd76e","id":"f34b1733-0339-41af-9fb1-f6dee2bfcc04","rack_id":"7aadeb89-bd00-4b44-8dba-79409603b38f","rack_name":"zNHMvLDMgbkfUIPtAhglCOwTg:RjWeunugnyPEEqdAfhxXBwAJK","rack_unit_size":1,"rack_unit_start":1,"sku":"FxCjKnuMmPTawRhYMJmKDWwrN","updated":"2020-01-26T19:04:26.241889Z"},{"created":"2020-01-26T19:04:26.303297Z","hardware_product_id":"2eca6269-a424-45f2-a3a9-a9913b8976ba","id":"2a3ef5b9-c936-478e-9e66-c097a7e16405","rack_id":"7aadeb89-bd00-4b44-8dba-79409603b38f","rack_name":"zNHMvLDMgbkfUIPtAhglCOwTg:RjWeunugnyPEEqdAfhxXBwAJK","rack_unit_size":2,"rack_unit_start":2,"sku":"xYxLsvSQYDsWVAxNTrUcxHIgL","updated":"2020-01-26T19:04:26.303297Z"}]'
     headers:
       Cache-Control:
       - no-cache
@@ -1525,17 +1555,17 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:21 GMT
+      - Sun, 26 Jan 2020 19:04:27 GMT
       Location:
-      - /rack/f5043389-7031-4ba1-84cc-05dbb71cecc7/layout
+      - /rack/7aadeb89-bd00-4b44-8dba-79409603b38f/layout
       Request-Id:
-      - qpkp8JQww5OS
+      - Sv6Wf3OMjeLd
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - qpkp8JQww5OS
+      - Sv6Wf3OMjeLd
     status: 200 OK
     code: 200
     duration: ""
@@ -1545,7 +1575,7 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/layout/f55efb0e-1e71-42ac-a23d-0a1427fe33f9
+    url: http://10.51.54.42:5000/layout/f34b1733-0339-41af-9fb1-f6dee2bfcc04
     method: DELETE
   response:
     body: ""
@@ -1553,13 +1583,13 @@ interactions:
       Cache-Control:
       - no-cache
       Date:
-      - Mon, 13 Jan 2020 23:16:21 GMT
+      - Sun, 26 Jan 2020 19:04:27 GMT
       Request-Id:
-      - rCcrTq9GZfyp
+      - OhiSnajt+K+c
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - rCcrTq9GZfyp
+      - OhiSnajt+K+c
     status: 204 No Content
     code: 204
     duration: ""
@@ -1569,7 +1599,7 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/layout/56a6bd3e-ea15-48c3-8ab5-f52748479f55
+    url: http://10.51.54.42:5000/layout/2a3ef5b9-c936-478e-9e66-c097a7e16405
     method: DELETE
   response:
     body: ""
@@ -1577,13 +1607,13 @@ interactions:
       Cache-Control:
       - no-cache
       Date:
-      - Mon, 13 Jan 2020 23:16:21 GMT
+      - Sun, 26 Jan 2020 19:04:27 GMT
       Request-Id:
-      - ZvGOg/qDevEL
+      - 1BOv/zAB4wau
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - ZvGOg/qDevEL
+      - 1BOv/zAB4wau
     status: 204 No Content
     code: 204
     duration: ""
@@ -1593,7 +1623,7 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/rack/f5043389-7031-4ba1-84cc-05dbb71cecc7
+    url: http://10.51.54.42:5000/rack/7aadeb89-bd00-4b44-8dba-79409603b38f
     method: DELETE
   response:
     body: ""
@@ -1601,13 +1631,13 @@ interactions:
       Cache-Control:
       - no-cache
       Date:
-      - Mon, 13 Jan 2020 23:16:22 GMT
+      - Sun, 26 Jan 2020 19:04:27 GMT
       Request-Id:
-      - hy0LUV3joBm3
+      - /7hM/VUO8MM/
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - hy0LUV3joBm3
+      - /7hM/VUO8MM/
     status: 204 No Content
     code: 204
     duration: ""
@@ -1617,7 +1647,7 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/rack_role/88d2fba0-22df-4ac9-b0ab-f911872415ef
+    url: http://10.51.54.42:5000/rack_role/b233a04d-d453-4730-8f4d-c945948c8d3b
     method: DELETE
   response:
     body: ""
@@ -1625,13 +1655,13 @@ interactions:
       Cache-Control:
       - no-cache
       Date:
-      - Mon, 13 Jan 2020 23:16:22 GMT
+      - Sun, 26 Jan 2020 19:04:27 GMT
       Request-Id:
-      - 0b0dz1nIt9v8
+      - V1PMPT8xHEFL
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - 0b0dz1nIt9v8
+      - V1PMPT8xHEFL
     status: 204 No Content
     code: 204
     duration: ""
@@ -1641,7 +1671,7 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/room/724a6c54-9676-4169-8475-728866852b43
+    url: http://10.51.54.42:5000/room/89ce0266-20fe-4136-a772-e2d9ace8d956
     method: DELETE
   response:
     body: ""
@@ -1649,13 +1679,13 @@ interactions:
       Cache-Control:
       - no-cache
       Date:
-      - Mon, 13 Jan 2020 23:16:22 GMT
+      - Sun, 26 Jan 2020 19:04:27 GMT
       Request-Id:
-      - D61zIqAxsAC6
+      - Pd/UAMZo4LsP
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - D61zIqAxsAC6
+      - Pd/UAMZo4LsP
     status: 204 No Content
     code: 204
     duration: ""
@@ -1665,7 +1695,7 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/dc/5e509013-7894-4e0e-a9bb-3e71d9f402c9
+    url: http://10.51.54.42:5000/dc/bc85ceef-2d58-45ae-a659-1b666f794795
     method: DELETE
   response:
     body: ""
@@ -1673,13 +1703,13 @@ interactions:
       Cache-Control:
       - no-cache
       Date:
-      - Mon, 13 Jan 2020 23:16:22 GMT
+      - Sun, 26 Jan 2020 19:04:27 GMT
       Request-Id:
-      - gT5sHB8K2Nve
+      - f8ZA/qrH1uk1
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - gT5sHB8K2Nve
+      - f8ZA/qrH1uk1
     status: 204 No Content
     code: 204
     duration: ""
@@ -1689,7 +1719,7 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/hardware_product/bb2996d4-b990-41f4-b073-2445969bea97
+    url: http://10.51.54.42:5000/hardware_product/6621614d-ad3d-42f7-8a6d-3cb94d8bd76e
     method: DELETE
   response:
     body: ""
@@ -1697,13 +1727,13 @@ interactions:
       Cache-Control:
       - no-cache
       Date:
-      - Mon, 13 Jan 2020 23:16:22 GMT
+      - Sun, 26 Jan 2020 19:04:27 GMT
       Request-Id:
-      - gcTVMHVAIXGZ
+      - c3REpBq036At
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - gcTVMHVAIXGZ
+      - c3REpBq036At
     status: 204 No Content
     code: 204
     duration: ""
@@ -1713,7 +1743,7 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/hardware_product/aec8b534-e365-4ea1-b297-e0cc77247671
+    url: http://10.51.54.42:5000/hardware_product/2eca6269-a424-45f2-a3a9-a9913b8976ba
     method: DELETE
   response:
     body: ""
@@ -1721,13 +1751,13 @@ interactions:
       Cache-Control:
       - no-cache
       Date:
-      - Mon, 13 Jan 2020 23:16:22 GMT
+      - Sun, 26 Jan 2020 19:04:27 GMT
       Request-Id:
-      - g6AsHnqwVw+U
+      - FzgftV1RI9lB
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - g6AsHnqwVw+U
+      - FzgftV1RI9lB
     status: 204 No Content
     code: 204
     duration: ""
@@ -1737,7 +1767,7 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/hardware_vendor/MyNewVendor
+    url: http://10.51.54.42:5000/hardware_vendor/713e2342-ed15-409d-a07c-bbca41941d92
     method: DELETE
   response:
     body: ""
@@ -1745,13 +1775,13 @@ interactions:
       Cache-Control:
       - no-cache
       Date:
-      - Mon, 13 Jan 2020 23:16:22 GMT
+      - Sun, 26 Jan 2020 19:04:27 GMT
       Request-Id:
-      - EzqMWqqpHhV0
+      - mhjduxXzfUld
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - EzqMWqqpHhV0
+      - mhjduxXzfUld
     status: 204 No Content
     code: 204
     duration: ""

--- a/fixtures/conch-v3/hardware.yaml
+++ b/fixtures/conch-v3/hardware.yaml
@@ -7,7 +7,33 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/hardware_vendor/MyNewVendor
+    url: http://10.51.54.42:5000/hardware_vendor/MyBigVendor
+    method: GET
+  response:
+    body: ""
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "0"
+      Date:
+      - Sun, 26 Jan 2020 19:04:27 GMT
+      Request-Id:
+      - yHryKLGiwfQs
+      Server:
+      - Mojolicious (Perl)
+      X-Request-Id:
+      - yHryKLGiwfQs
+    status: 410 Gone
+    code: 410
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Conch/3.x-testing
+    url: http://10.51.54.42:5000/hardware_vendor/MyBigVendor
     method: POST
   response:
     body: ""
@@ -17,15 +43,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Mon, 13 Jan 2020 23:16:22 GMT
+      - Sun, 26 Jan 2020 19:04:27 GMT
       Location:
-      - /hardware_vendor/MyNewVendor
+      - /hardware_vendor/MyBigVendor
       Request-Id:
-      - rLIoOr12vaFV
+      - O/RnQuIryh2M
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - rLIoOr12vaFV
+      - O/RnQuIryh2M
     status: 303 See Other
     code: 303
     duration: ""
@@ -34,13 +60,13 @@ interactions:
     form: {}
     headers:
       Referer:
-      - http://10.51.54.42:5000/hardware_vendor/MyNewVendor
+      - http://10.51.54.42:5000/hardware_vendor/MyBigVendor
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/hardware_vendor/MyNewVendor
+    url: http://10.51.54.42:5000/hardware_vendor/MyBigVendor
     method: GET
   response:
-    body: '{"created":"2020-01-13T23:16:22.201334Z","id":"ffa02983-7bc1-42d4-b5d9-165c3025b033","name":"MyNewVendor","updated":"2020-01-13T23:16:22.201334Z"}'
+    body: '{"created":"2020-01-26T19:04:27.318653Z","id":"26df0913-5614-4fec-beb7-3514df2a9356","name":"MyBigVendor","updated":"2020-01-26T19:04:27.318653Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -49,15 +75,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:22 GMT
+      - Sun, 26 Jan 2020 19:04:27 GMT
       Request-Id:
-      - McIeo7l21RYP
+      - lH2DCHJ6c0bK
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - McIeo7l21RYP
+      - lH2DCHJ6c0bK
     status: 200 OK
     code: 200
     duration: ""
@@ -67,10 +93,10 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/hardware_vendor/MyNewVendor
+    url: http://10.51.54.42:5000/hardware_vendor/MyBigVendor
     method: GET
   response:
-    body: '{"created":"2020-01-13T23:16:22.201334Z","id":"ffa02983-7bc1-42d4-b5d9-165c3025b033","name":"MyNewVendor","updated":"2020-01-13T23:16:22.201334Z"}'
+    body: '{"created":"2020-01-26T19:04:27.318653Z","id":"26df0913-5614-4fec-beb7-3514df2a9356","name":"MyBigVendor","updated":"2020-01-26T19:04:27.318653Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -79,15 +105,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:22 GMT
+      - Sun, 26 Jan 2020 19:04:27 GMT
       Request-Id:
-      - /zvmeJ4jTAV+
+      - sx/AkRN1wq8j
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - /zvmeJ4jTAV+
+      - sx/AkRN1wq8j
     status: 200 OK
     code: 200
     duration: ""
@@ -111,21 +137,21 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:22 GMT
+      - Sun, 26 Jan 2020 19:04:27 GMT
       Request-Id:
-      - Id0lmrh+IMt0
+      - 7HgUuktKxlmq
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - Id0lmrh+IMt0
+      - 7HgUuktKxlmq
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"alias":"HBwPfXkwBWcrGTEmKcfgcEAOQ","bios_firmware":"qksKNLZtEswqYITlEKWccPyAQ","cpu_type":"oVUponksFiJKAJzrpTptQPcPt","hardware_vendor_id":"ffa02983-7bc1-42d4-b5d9-165c3025b033","name":"dDAMUHVqGPGwhDuxMhUyArVcO","purpose":"epzmPvcsBoPlmoCxUuTfqyGdL","rack_unit_size":1,"sku":"LzAEPlUOObtGROufYxyILdKaJ","validation_plan_id":"a30ab8b2-8a9e-4e51-8bb0-92862abd8b54"}
+      {"alias":"VGyZdhHTSlKEevcIXLFdqLBqV","bios_firmware":"WyWzHYIRLAEpwgatcUwjipqkh","cpu_type":"XddLqzjJkILoECmoUYhruLOeT","hardware_vendor_id":"26df0913-5614-4fec-beb7-3514df2a9356","name":"vVrberRcPGVlljXeonTdwsovX","purpose":"BwdoYKPEhePiedtBHebHTdNnG","rack_unit_size":2,"sku":"aPHUOTzVZjFLgMpaBtWWZiXKw","validation_plan_id":"a30ab8b2-8a9e-4e51-8bb0-92862abd8b54"}
     form: {}
     headers:
       Content-Type:
@@ -142,15 +168,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Mon, 13 Jan 2020 23:16:22 GMT
+      - Sun, 26 Jan 2020 19:04:27 GMT
       Location:
-      - /hardware_product/1627da5b-db7e-4b62-b66c-2d7a0c380f50
+      - /hardware_product/6542884c-3515-49fe-9ebd-7da5da10e024
       Request-Id:
-      - V24LVCElR7zy
+      - MS4c0PaPyTic
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - V24LVCElR7zy
+      - MS4c0PaPyTic
     status: 303 See Other
     code: 303
     duration: ""
@@ -164,10 +190,10 @@ interactions:
       - http://10.51.54.42:5000/hardware_product
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/hardware_product/1627da5b-db7e-4b62-b66c-2d7a0c380f50
+    url: http://10.51.54.42:5000/hardware_product/6542884c-3515-49fe-9ebd-7da5da10e024
     method: GET
   response:
-    body: '{"alias":"HBwPfXkwBWcrGTEmKcfgcEAOQ","bios_firmware":"qksKNLZtEswqYITlEKWccPyAQ","cpu_num":0,"cpu_type":"oVUponksFiJKAJzrpTptQPcPt","created":"2020-01-13T23:16:22.286225Z","dimms_num":0,"generation_name":null,"hardware_vendor_id":"ffa02983-7bc1-42d4-b5d9-165c3025b033","hba_firmware":null,"id":"1627da5b-db7e-4b62-b66c-2d7a0c380f50","legacy_product_name":null,"name":"dDAMUHVqGPGwhDuxMhUyArVcO","nics_num":0,"nvme_ssd_num":0,"nvme_ssd_size":null,"nvme_ssd_slots":null,"prefix":null,"psu_total":0,"purpose":"epzmPvcsBoPlmoCxUuTfqyGdL","rack_unit_size":1,"raid_lun_num":0,"ram_total":0,"sas_hdd_num":0,"sas_hdd_size":null,"sas_hdd_slots":null,"sas_ssd_num":0,"sas_ssd_size":null,"sas_ssd_slots":null,"sata_hdd_num":0,"sata_hdd_size":null,"sata_hdd_slots":null,"sata_ssd_num":0,"sata_ssd_size":null,"sata_ssd_slots":null,"sku":"LzAEPlUOObtGROufYxyILdKaJ","specification":null,"updated":"2020-01-13T23:16:22.286225Z","usb_num":0,"validation_plan_id":"a30ab8b2-8a9e-4e51-8bb0-92862abd8b54"}'
+    body: '{"alias":"VGyZdhHTSlKEevcIXLFdqLBqV","bios_firmware":"WyWzHYIRLAEpwgatcUwjipqkh","cpu_num":0,"cpu_type":"XddLqzjJkILoECmoUYhruLOeT","created":"2020-01-26T19:04:27.394823Z","dimms_num":0,"generation_name":null,"hardware_vendor_id":"26df0913-5614-4fec-beb7-3514df2a9356","hba_firmware":null,"id":"6542884c-3515-49fe-9ebd-7da5da10e024","legacy_product_name":null,"name":"vVrberRcPGVlljXeonTdwsovX","nics_num":0,"nvme_ssd_num":0,"nvme_ssd_size":null,"nvme_ssd_slots":null,"prefix":null,"psu_total":0,"purpose":"BwdoYKPEhePiedtBHebHTdNnG","rack_unit_size":2,"raid_lun_num":0,"ram_total":0,"sas_hdd_num":0,"sas_hdd_size":null,"sas_hdd_slots":null,"sas_ssd_num":0,"sas_ssd_size":null,"sas_ssd_slots":null,"sata_hdd_num":0,"sata_hdd_size":null,"sata_hdd_slots":null,"sata_ssd_num":0,"sata_ssd_size":null,"sata_ssd_slots":null,"sku":"aPHUOTzVZjFLgMpaBtWWZiXKw","specification":null,"updated":"2020-01-26T19:04:27.394823Z","usb_num":0,"validation_plan_id":"a30ab8b2-8a9e-4e51-8bb0-92862abd8b54"}'
     headers:
       Cache-Control:
       - no-cache
@@ -176,17 +202,17 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:22 GMT
+      - Sun, 26 Jan 2020 19:04:27 GMT
       Location:
-      - /hardware_product/1627da5b-db7e-4b62-b66c-2d7a0c380f50
+      - /hardware_product/6542884c-3515-49fe-9ebd-7da5da10e024
       Request-Id:
-      - d4cv+xbQG9aM
+      - koTTlnYgOMcC
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - d4cv+xbQG9aM
+      - koTTlnYgOMcC
     status: 200 OK
     code: 200
     duration: ""
@@ -196,29 +222,27 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/hardware_product/dDAMUHVqGPGwhDuxMhUyArVcO
+    url: http://10.51.54.42:5000/hardware_product
     method: GET
   response:
-    body: '{"alias":"HBwPfXkwBWcrGTEmKcfgcEAOQ","bios_firmware":"qksKNLZtEswqYITlEKWccPyAQ","cpu_num":0,"cpu_type":"oVUponksFiJKAJzrpTptQPcPt","created":"2020-01-13T23:16:22.286225Z","dimms_num":0,"generation_name":null,"hardware_vendor_id":"ffa02983-7bc1-42d4-b5d9-165c3025b033","hba_firmware":null,"id":"1627da5b-db7e-4b62-b66c-2d7a0c380f50","legacy_product_name":null,"name":"dDAMUHVqGPGwhDuxMhUyArVcO","nics_num":0,"nvme_ssd_num":0,"nvme_ssd_size":null,"nvme_ssd_slots":null,"prefix":null,"psu_total":0,"purpose":"epzmPvcsBoPlmoCxUuTfqyGdL","rack_unit_size":1,"raid_lun_num":0,"ram_total":0,"sas_hdd_num":0,"sas_hdd_size":null,"sas_hdd_slots":null,"sas_ssd_num":0,"sas_ssd_size":null,"sas_ssd_slots":null,"sata_hdd_num":0,"sata_hdd_size":null,"sata_hdd_slots":null,"sata_ssd_num":0,"sata_ssd_size":null,"sata_ssd_slots":null,"sku":"LzAEPlUOObtGROufYxyILdKaJ","specification":null,"updated":"2020-01-13T23:16:22.286225Z","usb_num":0,"validation_plan_id":"a30ab8b2-8a9e-4e51-8bb0-92862abd8b54"}'
+    body: '[{"alias":"VGyZdhHTSlKEevcIXLFdqLBqV","bios_firmware":"WyWzHYIRLAEpwgatcUwjipqkh","cpu_num":0,"cpu_type":"XddLqzjJkILoECmoUYhruLOeT","created":"2020-01-26T19:04:27.394823Z","dimms_num":0,"generation_name":null,"hardware_vendor_id":"26df0913-5614-4fec-beb7-3514df2a9356","hba_firmware":null,"id":"6542884c-3515-49fe-9ebd-7da5da10e024","legacy_product_name":null,"name":"vVrberRcPGVlljXeonTdwsovX","nics_num":0,"nvme_ssd_num":0,"nvme_ssd_size":null,"nvme_ssd_slots":null,"prefix":null,"psu_total":0,"purpose":"BwdoYKPEhePiedtBHebHTdNnG","rack_unit_size":2,"raid_lun_num":0,"ram_total":0,"sas_hdd_num":0,"sas_hdd_size":null,"sas_hdd_slots":null,"sas_ssd_num":0,"sas_ssd_size":null,"sas_ssd_slots":null,"sata_hdd_num":0,"sata_hdd_size":null,"sata_hdd_slots":null,"sata_ssd_num":0,"sata_ssd_size":null,"sata_ssd_slots":null,"sku":"aPHUOTzVZjFLgMpaBtWWZiXKw","specification":null,"updated":"2020-01-26T19:04:27.394823Z","usb_num":0,"validation_plan_id":"a30ab8b2-8a9e-4e51-8bb0-92862abd8b54"}]'
     headers:
       Cache-Control:
       - no-cache
       Content-Length:
-      - "985"
+      - "987"
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:22 GMT
-      Location:
-      - /hardware_product/1627da5b-db7e-4b62-b66c-2d7a0c380f50
+      - Sun, 26 Jan 2020 19:04:27 GMT
       Request-Id:
-      - Qe7iINLBBucn
+      - FLz0SlzrwAvo
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - Qe7iINLBBucn
+      - FLz0SlzrwAvo
     status: 200 OK
     code: 200
     duration: ""
@@ -228,7 +252,39 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/hardware_product/1627da5b-db7e-4b62-b66c-2d7a0c380f50
+    url: http://10.51.54.42:5000/hardware_product/vVrberRcPGVlljXeonTdwsovX
+    method: GET
+  response:
+    body: '{"alias":"VGyZdhHTSlKEevcIXLFdqLBqV","bios_firmware":"WyWzHYIRLAEpwgatcUwjipqkh","cpu_num":0,"cpu_type":"XddLqzjJkILoECmoUYhruLOeT","created":"2020-01-26T19:04:27.394823Z","dimms_num":0,"generation_name":null,"hardware_vendor_id":"26df0913-5614-4fec-beb7-3514df2a9356","hba_firmware":null,"id":"6542884c-3515-49fe-9ebd-7da5da10e024","legacy_product_name":null,"name":"vVrberRcPGVlljXeonTdwsovX","nics_num":0,"nvme_ssd_num":0,"nvme_ssd_size":null,"nvme_ssd_slots":null,"prefix":null,"psu_total":0,"purpose":"BwdoYKPEhePiedtBHebHTdNnG","rack_unit_size":2,"raid_lun_num":0,"ram_total":0,"sas_hdd_num":0,"sas_hdd_size":null,"sas_hdd_slots":null,"sas_ssd_num":0,"sas_ssd_size":null,"sas_ssd_slots":null,"sata_hdd_num":0,"sata_hdd_size":null,"sata_hdd_slots":null,"sata_ssd_num":0,"sata_ssd_size":null,"sata_ssd_slots":null,"sku":"aPHUOTzVZjFLgMpaBtWWZiXKw","specification":null,"updated":"2020-01-26T19:04:27.394823Z","usb_num":0,"validation_plan_id":"a30ab8b2-8a9e-4e51-8bb0-92862abd8b54"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "985"
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 26 Jan 2020 19:04:27 GMT
+      Location:
+      - /hardware_product/6542884c-3515-49fe-9ebd-7da5da10e024
+      Request-Id:
+      - TbsmficXO0YH
+      Server:
+      - Mojolicious (Perl)
+      X-Conch-Api:
+      - v3.0.0-b4-0-gb99fbfff
+      X-Request-Id:
+      - TbsmficXO0YH
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Conch/3.x-testing
+    url: http://10.51.54.42:5000/hardware_product/6542884c-3515-49fe-9ebd-7da5da10e024
     method: DELETE
   response:
     body: ""
@@ -236,13 +292,13 @@ interactions:
       Cache-Control:
       - no-cache
       Date:
-      - Mon, 13 Jan 2020 23:16:22 GMT
+      - Sun, 26 Jan 2020 19:04:27 GMT
       Request-Id:
-      - j8tQSWrcQoGD
+      - l4BtZ5cGuzA5
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - j8tQSWrcQoGD
+      - l4BtZ5cGuzA5
     status: 204 No Content
     code: 204
     duration: ""
@@ -252,7 +308,264 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/hardware_vendor/MyNewVendor
+    url: http://10.51.54.42:5000/hardware_product
+    method: GET
+  response:
+    body: '[]'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 26 Jan 2020 19:04:27 GMT
+      Request-Id:
+      - 1NZOerYeQzWD
+      Server:
+      - Mojolicious (Perl)
+      X-Conch-Api:
+      - v3.0.0-b4-0-gb99fbfff
+      X-Request-Id:
+      - 1NZOerYeQzWD
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Conch/3.x-testing
+    url: http://10.51.54.42:5000/validation_plan/a30ab8b2-8a9e-4e51-8bb0-92862abd8b54
+    method: GET
+  response:
+    body: '{"created":"2019-10-09T17:21:37.861483Z","description":"Validation plan
+      containing all validations run in Conch v1 on servers","id":"a30ab8b2-8a9e-4e51-8bb0-92862abd8b54","name":"Conch
+      v1 Legacy Plan: Server"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "209"
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 26 Jan 2020 19:04:27 GMT
+      Request-Id:
+      - Uy+k2xde7ghB
+      Server:
+      - Mojolicious (Perl)
+      X-Conch-Api:
+      - v3.0.0-b4-0-gb99fbfff
+      X-Request-Id:
+      - Uy+k2xde7ghB
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Conch/3.x-testing
+    url: http://10.51.54.42:5000/hardware_vendor/MyBigVendor
+    method: GET
+  response:
+    body: '{"created":"2020-01-26T19:04:27.318653Z","id":"26df0913-5614-4fec-beb7-3514df2a9356","name":"MyBigVendor","updated":"2020-01-26T19:04:27.318653Z"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "146"
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 26 Jan 2020 19:04:27 GMT
+      Request-Id:
+      - By8YIJ4rIiYz
+      Server:
+      - Mojolicious (Perl)
+      X-Conch-Api:
+      - v3.0.0-b4-0-gb99fbfff
+      X-Request-Id:
+      - By8YIJ4rIiYz
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: |
+      {"alias":"ujOmocHFAUuWZILajRAzVkeuO","bios_firmware":"RcgHsdxbvsvNXWQMpuLchiLgH","cpu_type":"FEkEUQAJTUIwzzxxHsXjxWJqN","hardware_vendor_id":"26df0913-5614-4fec-beb7-3514df2a9356","name":"Testy McTesterson","purpose":"FCYNIyfxlJtZmSIluDaoPNwRD","rack_unit_size":2,"sku":"test-sku-001","validation_plan_id":"a30ab8b2-8a9e-4e51-8bb0-92862abd8b54"}
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Conch/3.x-testing
+    url: http://10.51.54.42:5000/hardware_product
+    method: POST
+  response:
+    body: ""
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "0"
+      Date:
+      - Sun, 26 Jan 2020 19:04:27 GMT
+      Location:
+      - /hardware_product/9ad55ceb-2eb7-4125-a492-3c595277b3e3
+      Request-Id:
+      - nhTT+fVwUqSP
+      Server:
+      - Mojolicious (Perl)
+      X-Request-Id:
+      - nhTT+fVwUqSP
+    status: 303 See Other
+    code: 303
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      Referer:
+      - http://10.51.54.42:5000/hardware_product
+      User-Agent:
+      - Conch/3.x-testing
+    url: http://10.51.54.42:5000/hardware_product/9ad55ceb-2eb7-4125-a492-3c595277b3e3
+    method: GET
+  response:
+    body: '{"alias":"ujOmocHFAUuWZILajRAzVkeuO","bios_firmware":"RcgHsdxbvsvNXWQMpuLchiLgH","cpu_num":0,"cpu_type":"FEkEUQAJTUIwzzxxHsXjxWJqN","created":"2020-01-26T19:04:27.567389Z","dimms_num":0,"generation_name":null,"hardware_vendor_id":"26df0913-5614-4fec-beb7-3514df2a9356","hba_firmware":null,"id":"9ad55ceb-2eb7-4125-a492-3c595277b3e3","legacy_product_name":null,"name":"Testy
+      McTesterson","nics_num":0,"nvme_ssd_num":0,"nvme_ssd_size":null,"nvme_ssd_slots":null,"prefix":null,"psu_total":0,"purpose":"FCYNIyfxlJtZmSIluDaoPNwRD","rack_unit_size":2,"raid_lun_num":0,"ram_total":0,"sas_hdd_num":0,"sas_hdd_size":null,"sas_hdd_slots":null,"sas_ssd_num":0,"sas_ssd_size":null,"sas_ssd_slots":null,"sata_hdd_num":0,"sata_hdd_size":null,"sata_hdd_slots":null,"sata_ssd_num":0,"sata_ssd_size":null,"sata_ssd_slots":null,"sku":"test-sku-001","specification":null,"updated":"2020-01-26T19:04:27.567389Z","usb_num":0,"validation_plan_id":"a30ab8b2-8a9e-4e51-8bb0-92862abd8b54"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "964"
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 26 Jan 2020 19:04:27 GMT
+      Location:
+      - /hardware_product/9ad55ceb-2eb7-4125-a492-3c595277b3e3
+      Request-Id:
+      - jKX0hRSPa2SP
+      Server:
+      - Mojolicious (Perl)
+      X-Conch-Api:
+      - v3.0.0-b4-0-gb99fbfff
+      X-Request-Id:
+      - jKX0hRSPa2SP
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Conch/3.x-testing
+    url: http://10.51.54.42:5000/hardware_product
+    method: GET
+  response:
+    body: '[{"alias":"ujOmocHFAUuWZILajRAzVkeuO","bios_firmware":"RcgHsdxbvsvNXWQMpuLchiLgH","cpu_num":0,"cpu_type":"FEkEUQAJTUIwzzxxHsXjxWJqN","created":"2020-01-26T19:04:27.567389Z","dimms_num":0,"generation_name":null,"hardware_vendor_id":"26df0913-5614-4fec-beb7-3514df2a9356","hba_firmware":null,"id":"9ad55ceb-2eb7-4125-a492-3c595277b3e3","legacy_product_name":null,"name":"Testy
+      McTesterson","nics_num":0,"nvme_ssd_num":0,"nvme_ssd_size":null,"nvme_ssd_slots":null,"prefix":null,"psu_total":0,"purpose":"FCYNIyfxlJtZmSIluDaoPNwRD","rack_unit_size":2,"raid_lun_num":0,"ram_total":0,"sas_hdd_num":0,"sas_hdd_size":null,"sas_hdd_slots":null,"sas_ssd_num":0,"sas_ssd_size":null,"sas_ssd_slots":null,"sata_hdd_num":0,"sata_hdd_size":null,"sata_hdd_slots":null,"sata_ssd_num":0,"sata_ssd_size":null,"sata_ssd_slots":null,"sku":"test-sku-001","specification":null,"updated":"2020-01-26T19:04:27.567389Z","usb_num":0,"validation_plan_id":"a30ab8b2-8a9e-4e51-8bb0-92862abd8b54"}]'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "966"
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 26 Jan 2020 19:04:27 GMT
+      Request-Id:
+      - 5LybBpqXOWyy
+      Server:
+      - Mojolicious (Perl)
+      X-Conch-Api:
+      - v3.0.0-b4-0-gb99fbfff
+      X-Request-Id:
+      - 5LybBpqXOWyy
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Conch/3.x-testing
+    url: http://10.51.54.42:5000/hardware_product/test-sku-001
+    method: GET
+  response:
+    body: '{"alias":"ujOmocHFAUuWZILajRAzVkeuO","bios_firmware":"RcgHsdxbvsvNXWQMpuLchiLgH","cpu_num":0,"cpu_type":"FEkEUQAJTUIwzzxxHsXjxWJqN","created":"2020-01-26T19:04:27.567389Z","dimms_num":0,"generation_name":null,"hardware_vendor_id":"26df0913-5614-4fec-beb7-3514df2a9356","hba_firmware":null,"id":"9ad55ceb-2eb7-4125-a492-3c595277b3e3","legacy_product_name":null,"name":"Testy
+      McTesterson","nics_num":0,"nvme_ssd_num":0,"nvme_ssd_size":null,"nvme_ssd_slots":null,"prefix":null,"psu_total":0,"purpose":"FCYNIyfxlJtZmSIluDaoPNwRD","rack_unit_size":2,"raid_lun_num":0,"ram_total":0,"sas_hdd_num":0,"sas_hdd_size":null,"sas_hdd_slots":null,"sas_ssd_num":0,"sas_ssd_size":null,"sas_ssd_slots":null,"sata_hdd_num":0,"sata_hdd_size":null,"sata_hdd_slots":null,"sata_ssd_num":0,"sata_ssd_size":null,"sata_ssd_slots":null,"sku":"test-sku-001","specification":null,"updated":"2020-01-26T19:04:27.567389Z","usb_num":0,"validation_plan_id":"a30ab8b2-8a9e-4e51-8bb0-92862abd8b54"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "964"
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 26 Jan 2020 19:04:27 GMT
+      Location:
+      - /hardware_product/9ad55ceb-2eb7-4125-a492-3c595277b3e3
+      Request-Id:
+      - rZjWwuRlUXNA
+      Server:
+      - Mojolicious (Perl)
+      X-Conch-Api:
+      - v3.0.0-b4-0-gb99fbfff
+      X-Request-Id:
+      - rZjWwuRlUXNA
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Conch/3.x-testing
+    url: http://10.51.54.42:5000/hardware_product/test-sku-001
+    method: GET
+  response:
+    body: '{"alias":"ujOmocHFAUuWZILajRAzVkeuO","bios_firmware":"RcgHsdxbvsvNXWQMpuLchiLgH","cpu_num":0,"cpu_type":"FEkEUQAJTUIwzzxxHsXjxWJqN","created":"2020-01-26T19:04:27.567389Z","dimms_num":0,"generation_name":null,"hardware_vendor_id":"26df0913-5614-4fec-beb7-3514df2a9356","hba_firmware":null,"id":"9ad55ceb-2eb7-4125-a492-3c595277b3e3","legacy_product_name":null,"name":"Testy
+      McTesterson","nics_num":0,"nvme_ssd_num":0,"nvme_ssd_size":null,"nvme_ssd_slots":null,"prefix":null,"psu_total":0,"purpose":"FCYNIyfxlJtZmSIluDaoPNwRD","rack_unit_size":2,"raid_lun_num":0,"ram_total":0,"sas_hdd_num":0,"sas_hdd_size":null,"sas_hdd_slots":null,"sas_ssd_num":0,"sas_ssd_size":null,"sas_ssd_slots":null,"sata_hdd_num":0,"sata_hdd_size":null,"sata_hdd_slots":null,"sata_ssd_num":0,"sata_ssd_size":null,"sata_ssd_slots":null,"sku":"test-sku-001","specification":null,"updated":"2020-01-26T19:04:27.567389Z","usb_num":0,"validation_plan_id":"a30ab8b2-8a9e-4e51-8bb0-92862abd8b54"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "964"
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 26 Jan 2020 19:04:27 GMT
+      Location:
+      - /hardware_product/9ad55ceb-2eb7-4125-a492-3c595277b3e3
+      Request-Id:
+      - hKSVv8weWwWQ
+      Server:
+      - Mojolicious (Perl)
+      X-Conch-Api:
+      - v3.0.0-b4-0-gb99fbfff
+      X-Request-Id:
+      - hKSVv8weWwWQ
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Conch/3.x-testing
+    url: http://10.51.54.42:5000/hardware_product/9ad55ceb-2eb7-4125-a492-3c595277b3e3
     method: DELETE
   response:
     body: ""
@@ -260,13 +573,67 @@ interactions:
       Cache-Control:
       - no-cache
       Date:
-      - Mon, 13 Jan 2020 23:16:22 GMT
+      - Sun, 26 Jan 2020 19:04:27 GMT
       Request-Id:
-      - Ctg+cAJvu8Ee
+      - G71rcNshbzNR
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - Ctg+cAJvu8Ee
+      - G71rcNshbzNR
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Conch/3.x-testing
+    url: http://10.51.54.42:5000/hardware_product
+    method: GET
+  response:
+    body: '[]'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 26 Jan 2020 19:04:27 GMT
+      Request-Id:
+      - 5YyZpFY6Qs9n
+      Server:
+      - Mojolicious (Perl)
+      X-Conch-Api:
+      - v3.0.0-b4-0-gb99fbfff
+      X-Request-Id:
+      - 5YyZpFY6Qs9n
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Conch/3.x-testing
+    url: http://10.51.54.42:5000/hardware_vendor/26df0913-5614-4fec-beb7-3514df2a9356
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Cache-Control:
+      - no-cache
+      Date:
+      - Sun, 26 Jan 2020 19:04:27 GMT
+      Request-Id:
+      - mmDKcSoCyYs3
+      Server:
+      - Mojolicious (Perl)
+      X-Request-Id:
+      - mmDKcSoCyYs3
     status: 204 No Content
     code: 204
     duration: ""

--- a/fixtures/conch-v3/racks.yaml
+++ b/fixtures/conch-v3/racks.yaml
@@ -3,7 +3,7 @@ version: 1
 interactions:
 - request:
     body: |
-      {"name":"fFORUxYSaMDydfplzVwbnxfwv","rack_size":60}
+      {"name":"ZHUfcaVHyETwvBjCbSzrvORQb","rack_size":60}
     form: {}
     headers:
       Content-Type:
@@ -20,15 +20,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Mon, 13 Jan 2020 23:16:22 GMT
+      - Sun, 26 Jan 2020 19:04:27 GMT
       Location:
-      - /rack_role/9b6e660f-0dd7-4755-951b-0872fa9b9669
+      - /rack_role/7c795de7-9ac6-4bc2-aaca-9ff0e2a99ef0
       Request-Id:
-      - h9zEp/QRHON4
+      - 0vfOKzb8EBJh
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - h9zEp/QRHON4
+      - 0vfOKzb8EBJh
     status: 303 See Other
     code: 303
     duration: ""
@@ -42,10 +42,10 @@ interactions:
       - http://10.51.54.42:5000/rack_role
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/rack_role/9b6e660f-0dd7-4755-951b-0872fa9b9669
+    url: http://10.51.54.42:5000/rack_role/7c795de7-9ac6-4bc2-aaca-9ff0e2a99ef0
     method: GET
   response:
-    body: '{"created":"2020-01-13T23:16:22.637624Z","id":"9b6e660f-0dd7-4755-951b-0872fa9b9669","name":"fFORUxYSaMDydfplzVwbnxfwv","rack_size":60,"updated":"2020-01-13T23:16:22.637624Z"}'
+    body: '{"created":"2020-01-26T19:04:27.963266Z","id":"7c795de7-9ac6-4bc2-aaca-9ff0e2a99ef0","name":"ZHUfcaVHyETwvBjCbSzrvORQb","rack_size":60,"updated":"2020-01-26T19:04:27.963266Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -54,21 +54,21 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:22 GMT
+      - Sun, 26 Jan 2020 19:04:27 GMT
       Request-Id:
-      - si8HlJat7+kk
+      - 1kN4DE8CfJxB
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - si8HlJat7+kk
+      - 1kN4DE8CfJxB
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"location":"OjuywPKOjJDvjgykSMwAREAGc","region":"OijkQuUWESHCuzPxqDSzosgIG","vendor":"HDjLXqjoOpdhmPDhncwgRvLlK","vendor_name":"kyZOMGNXsekIZBUvMgYvvsjwV"}
+      {"location":"pMwuTfBzqDIvygBQlXGSujHFC","region":"cqKbObYEpySHaBapdkTsqpCbw","vendor":"JVpDAsNbghvVnEOoVCXefIqcu","vendor_name":"helkfqqzCfcKGOnefVwjTxpdP"}
     form: {}
     headers:
       Content-Type:
@@ -85,15 +85,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Mon, 13 Jan 2020 23:16:22 GMT
+      - Sun, 26 Jan 2020 19:04:27 GMT
       Location:
-      - /dc/4361c5ba-6be1-4047-872c-eaea4c3177c5
+      - /dc/7833a223-1395-4541-a471-d91d7ba846ab
       Request-Id:
-      - jfMOxRCIp1ka
+      - 5ZT28naHLau3
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - jfMOxRCIp1ka
+      - 5ZT28naHLau3
     status: 201 Created
     code: 201
     duration: ""
@@ -103,10 +103,10 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/dc/4361c5ba-6be1-4047-872c-eaea4c3177c5
+    url: http://10.51.54.42:5000/dc/7833a223-1395-4541-a471-d91d7ba846ab
     method: GET
   response:
-    body: '{"created":"2020-01-13T23:16:22.680248Z","id":"4361c5ba-6be1-4047-872c-eaea4c3177c5","location":"OjuywPKOjJDvjgykSMwAREAGc","region":"OijkQuUWESHCuzPxqDSzosgIG","updated":"2020-01-13T23:16:22.680248Z","vendor":"HDjLXqjoOpdhmPDhncwgRvLlK","vendor_name":"kyZOMGNXsekIZBUvMgYvvsjwV"}'
+    body: '{"created":"2020-01-26T19:04:28.002386Z","id":"7833a223-1395-4541-a471-d91d7ba846ab","location":"pMwuTfBzqDIvygBQlXGSujHFC","region":"cqKbObYEpySHaBapdkTsqpCbw","updated":"2020-01-26T19:04:28.002386Z","vendor":"JVpDAsNbghvVnEOoVCXefIqcu","vendor_name":"helkfqqzCfcKGOnefVwjTxpdP"}'
     headers:
       Cache-Control:
       - no-cache
@@ -115,21 +115,21 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:22 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Request-Id:
-      - 3wKOnSaqDqB0
+      - U/oYOpmOCU9X
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - 3wKOnSaqDqB0
+      - U/oYOpmOCU9X
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"alias":"cAGSLmBFBqjeUzknwoJwQpNMd","az":"CvChoGaoYtibzraFdzWNcnWtw","datacenter_id":"4361c5ba-6be1-4047-872c-eaea4c3177c5","vendor_name":"EiKkKbgXjdswqZMzIYcDKMxQE"}
+      {"alias":"vjdBBzhinOfupWTAsEKOvwGew","az":"AMfKdCbXyumqdNdnHVylqSswg","datacenter_id":"7833a223-1395-4541-a471-d91d7ba846ab","vendor_name":"OuzjBCPvhKBFhyRpMGYglHBfi"}
     form: {}
     headers:
       Content-Type:
@@ -146,15 +146,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Mon, 13 Jan 2020 23:16:22 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Location:
-      - /room/52ec7cb8-c954-4416-be38-d1b21766102e
+      - /room/7facfdc8-4155-4a68-9f28-2ce6b72f1d84
       Request-Id:
-      - /oQhQByWeetQ
+      - 1r3LeF1lnNse
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - /oQhQByWeetQ
+      - 1r3LeF1lnNse
     status: 303 See Other
     code: 303
     duration: ""
@@ -168,10 +168,10 @@ interactions:
       - http://10.51.54.42:5000/room
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/room/52ec7cb8-c954-4416-be38-d1b21766102e
+    url: http://10.51.54.42:5000/room/7facfdc8-4155-4a68-9f28-2ce6b72f1d84
     method: GET
   response:
-    body: '{"alias":"cAGSLmBFBqjeUzknwoJwQpNMd","az":"CvChoGaoYtibzraFdzWNcnWtw","created":"2020-01-13T23:16:22.722486Z","datacenter_id":"4361c5ba-6be1-4047-872c-eaea4c3177c5","id":"52ec7cb8-c954-4416-be38-d1b21766102e","updated":"2020-01-13T23:16:22.722486Z","vendor_name":"EiKkKbgXjdswqZMzIYcDKMxQE"}'
+    body: '{"alias":"vjdBBzhinOfupWTAsEKOvwGew","az":"AMfKdCbXyumqdNdnHVylqSswg","created":"2020-01-26T19:04:28.041112Z","datacenter_id":"7833a223-1395-4541-a471-d91d7ba846ab","id":"7facfdc8-4155-4a68-9f28-2ce6b72f1d84","updated":"2020-01-26T19:04:28.041112Z","vendor_name":"OuzjBCPvhKBFhyRpMGYglHBfi"}'
     headers:
       Cache-Control:
       - no-cache
@@ -180,17 +180,17 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:22 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Location:
-      - /room/52ec7cb8-c954-4416-be38-d1b21766102e
+      - /room/7facfdc8-4155-4a68-9f28-2ce6b72f1d84
       Request-Id:
-      - Oiy+7nC4HNfe
+      - qe6TSXhLeTz5
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - Oiy+7nC4HNfe
+      - qe6TSXhLeTz5
     status: 200 OK
     code: 200
     duration: ""
@@ -200,7 +200,33 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/hardware_vendor/MyNewVendor
+    url: http://10.51.54.42:5000/hardware_vendor/MyBigVendor
+    method: GET
+  response:
+    body: ""
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "0"
+      Date:
+      - Sun, 26 Jan 2020 19:04:28 GMT
+      Request-Id:
+      - 1nzwPoQqof06
+      Server:
+      - Mojolicious (Perl)
+      X-Request-Id:
+      - 1nzwPoQqof06
+    status: 410 Gone
+    code: 410
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Conch/3.x-testing
+    url: http://10.51.54.42:5000/hardware_vendor/MyBigVendor
     method: POST
   response:
     body: ""
@@ -210,15 +236,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Mon, 13 Jan 2020 23:16:22 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Location:
-      - /hardware_vendor/MyNewVendor
+      - /hardware_vendor/MyBigVendor
       Request-Id:
-      - pHVdek1BGP1A
+      - Zs8yWfSYpwtd
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - pHVdek1BGP1A
+      - Zs8yWfSYpwtd
     status: 303 See Other
     code: 303
     duration: ""
@@ -227,13 +253,13 @@ interactions:
     form: {}
     headers:
       Referer:
-      - http://10.51.54.42:5000/hardware_vendor/MyNewVendor
+      - http://10.51.54.42:5000/hardware_vendor/MyBigVendor
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/hardware_vendor/MyNewVendor
+    url: http://10.51.54.42:5000/hardware_vendor/MyBigVendor
     method: GET
   response:
-    body: '{"created":"2020-01-13T23:16:22.765764Z","id":"69b8ba60-3134-4355-bda1-99930d51dc37","name":"MyNewVendor","updated":"2020-01-13T23:16:22.765764Z"}'
+    body: '{"created":"2020-01-26T19:04:28.095805Z","id":"3d28519c-66c8-4342-8220-4e1cae887e2d","name":"MyBigVendor","updated":"2020-01-26T19:04:28.095805Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -242,15 +268,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:22 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Request-Id:
-      - zuvdguZxpXQ6
+      - E+iPCa8uPYMq
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - zuvdguZxpXQ6
+      - E+iPCa8uPYMq
     status: 200 OK
     code: 200
     duration: ""
@@ -260,10 +286,10 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/hardware_vendor/MyNewVendor
+    url: http://10.51.54.42:5000/hardware_vendor/MyBigVendor
     method: GET
   response:
-    body: '{"created":"2020-01-13T23:16:22.765764Z","id":"69b8ba60-3134-4355-bda1-99930d51dc37","name":"MyNewVendor","updated":"2020-01-13T23:16:22.765764Z"}'
+    body: '{"created":"2020-01-26T19:04:28.095805Z","id":"3d28519c-66c8-4342-8220-4e1cae887e2d","name":"MyBigVendor","updated":"2020-01-26T19:04:28.095805Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -272,15 +298,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:22 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Request-Id:
-      - oPzTN2F/9JvX
+      - ieHJQROFOy9O
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - oPzTN2F/9JvX
+      - ieHJQROFOy9O
     status: 200 OK
     code: 200
     duration: ""
@@ -304,21 +330,21 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:22 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Request-Id:
-      - xVGoiYV9u27h
+      - uDYc6dTe9fR+
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - xVGoiYV9u27h
+      - uDYc6dTe9fR+
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"alias":"cdrJJNbkuIqiWIHfStrLanJvn","bios_firmware":"peXxkuhaUTIYCYgMflWliFork","cpu_type":"BgTxQYrzwFWPjyAJUEMnskNUr","hardware_vendor_id":"69b8ba60-3134-4355-bda1-99930d51dc37","name":"weKLXRefjnllqmUiIbdyAKOcc","purpose":"eFedOEoKzvOTJLcFFNfwAZKPf","rack_unit_size":1,"sku":"ueiumFKFIPGkCCRJEDgJhFtrr","validation_plan_id":"a30ab8b2-8a9e-4e51-8bb0-92862abd8b54"}
+      {"alias":"HrZIMrVpcWqZgaUulBthQcOag","bios_firmware":"MnUVOnKQRdqBIceuwfwrWEjhW","cpu_type":"VnLtfCOjaztZvISSPHEiVKiQZ","hardware_vendor_id":"3d28519c-66c8-4342-8220-4e1cae887e2d","name":"oYVmnkaHmHTuHKrcEesRozYeT","purpose":"znqMcuZEZIkFJlfstVGYwPpkq","rack_unit_size":1,"sku":"qDwDpLdrLFrPEqjOOUrmyGirY","validation_plan_id":"a30ab8b2-8a9e-4e51-8bb0-92862abd8b54"}
     form: {}
     headers:
       Content-Type:
@@ -335,15 +361,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Mon, 13 Jan 2020 23:16:22 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Location:
-      - /hardware_product/01390cbe-7daa-4a4e-b005-d36c9972bfdd
+      - /hardware_product/4d97ab05-0d97-47aa-862d-82bb2ee0468a
       Request-Id:
-      - rWF3P2vruCGQ
+      - OSPhfPpzmMLm
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - rWF3P2vruCGQ
+      - OSPhfPpzmMLm
     status: 303 See Other
     code: 303
     duration: ""
@@ -357,10 +383,10 @@ interactions:
       - http://10.51.54.42:5000/hardware_product
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/hardware_product/01390cbe-7daa-4a4e-b005-d36c9972bfdd
+    url: http://10.51.54.42:5000/hardware_product/4d97ab05-0d97-47aa-862d-82bb2ee0468a
     method: GET
   response:
-    body: '{"alias":"cdrJJNbkuIqiWIHfStrLanJvn","bios_firmware":"peXxkuhaUTIYCYgMflWliFork","cpu_num":0,"cpu_type":"BgTxQYrzwFWPjyAJUEMnskNUr","created":"2020-01-13T23:16:22.855321Z","dimms_num":0,"generation_name":null,"hardware_vendor_id":"69b8ba60-3134-4355-bda1-99930d51dc37","hba_firmware":null,"id":"01390cbe-7daa-4a4e-b005-d36c9972bfdd","legacy_product_name":null,"name":"weKLXRefjnllqmUiIbdyAKOcc","nics_num":0,"nvme_ssd_num":0,"nvme_ssd_size":null,"nvme_ssd_slots":null,"prefix":null,"psu_total":0,"purpose":"eFedOEoKzvOTJLcFFNfwAZKPf","rack_unit_size":1,"raid_lun_num":0,"ram_total":0,"sas_hdd_num":0,"sas_hdd_size":null,"sas_hdd_slots":null,"sas_ssd_num":0,"sas_ssd_size":null,"sas_ssd_slots":null,"sata_hdd_num":0,"sata_hdd_size":null,"sata_hdd_slots":null,"sata_ssd_num":0,"sata_ssd_size":null,"sata_ssd_slots":null,"sku":"ueiumFKFIPGkCCRJEDgJhFtrr","specification":null,"updated":"2020-01-13T23:16:22.855321Z","usb_num":0,"validation_plan_id":"a30ab8b2-8a9e-4e51-8bb0-92862abd8b54"}'
+    body: '{"alias":"HrZIMrVpcWqZgaUulBthQcOag","bios_firmware":"MnUVOnKQRdqBIceuwfwrWEjhW","cpu_num":0,"cpu_type":"VnLtfCOjaztZvISSPHEiVKiQZ","created":"2020-01-26T19:04:28.181783Z","dimms_num":0,"generation_name":null,"hardware_vendor_id":"3d28519c-66c8-4342-8220-4e1cae887e2d","hba_firmware":null,"id":"4d97ab05-0d97-47aa-862d-82bb2ee0468a","legacy_product_name":null,"name":"oYVmnkaHmHTuHKrcEesRozYeT","nics_num":0,"nvme_ssd_num":0,"nvme_ssd_size":null,"nvme_ssd_slots":null,"prefix":null,"psu_total":0,"purpose":"znqMcuZEZIkFJlfstVGYwPpkq","rack_unit_size":1,"raid_lun_num":0,"ram_total":0,"sas_hdd_num":0,"sas_hdd_size":null,"sas_hdd_slots":null,"sas_ssd_num":0,"sas_ssd_size":null,"sas_ssd_slots":null,"sata_hdd_num":0,"sata_hdd_size":null,"sata_hdd_slots":null,"sata_ssd_num":0,"sata_ssd_size":null,"sata_ssd_slots":null,"sku":"qDwDpLdrLFrPEqjOOUrmyGirY","specification":null,"updated":"2020-01-26T19:04:28.181783Z","usb_num":0,"validation_plan_id":"a30ab8b2-8a9e-4e51-8bb0-92862abd8b54"}'
     headers:
       Cache-Control:
       - no-cache
@@ -369,23 +395,23 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:22 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Location:
-      - /hardware_product/01390cbe-7daa-4a4e-b005-d36c9972bfdd
+      - /hardware_product/4d97ab05-0d97-47aa-862d-82bb2ee0468a
       Request-Id:
-      - Ni6JDk01J5HI
+      - oC97IiVy1afF
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - Ni6JDk01J5HI
+      - oC97IiVy1afF
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"alias":"RbJqbiCtgxVwwiexaoAcPPRtO","bios_firmware":"cklDuNjZvuriBSHtpAKGiQuVq","cpu_type":"clmhxFxElLDctiiDlgKmNPvRM","hardware_vendor_id":"69b8ba60-3134-4355-bda1-99930d51dc37","name":"ZRloivsvIVzSZhaYBZHcsrnMh","purpose":"EpxbsjfFxQJkBRlmPDqjFDdoz","rack_unit_size":1,"sku":"AWFiqyOSIjFfuxPiHprFQiQnw","validation_plan_id":"a30ab8b2-8a9e-4e51-8bb0-92862abd8b54"}
+      {"alias":"kzdrzOFbSzwABLXZJgiRbeCyZ","bios_firmware":"YBMTTKmRmcMJdeudbCHnLdWTA","cpu_type":"IjGVEsUTFgtcqCgykUYFkzSlh","hardware_vendor_id":"3d28519c-66c8-4342-8220-4e1cae887e2d","name":"dpVmuHtPowtbsWxgeQGGhDxzq","purpose":"aqjoVIMEkFxHTVJUbjbuQOjnq","rack_unit_size":1,"sku":"kCKOViIEFgkEhdhcQFxItjUmb","validation_plan_id":"a30ab8b2-8a9e-4e51-8bb0-92862abd8b54"}
     form: {}
     headers:
       Content-Type:
@@ -402,15 +428,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Mon, 13 Jan 2020 23:16:22 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Location:
-      - /hardware_product/687be698-32a7-42f0-a669-0751d851563c
+      - /hardware_product/cd87e849-5520-4601-86ef-5998ae6cde12
       Request-Id:
-      - Q4P85sC22Ub3
+      - 3pbS9B/+gQaW
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - Q4P85sC22Ub3
+      - 3pbS9B/+gQaW
     status: 303 See Other
     code: 303
     duration: ""
@@ -424,10 +450,10 @@ interactions:
       - http://10.51.54.42:5000/hardware_product
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/hardware_product/687be698-32a7-42f0-a669-0751d851563c
+    url: http://10.51.54.42:5000/hardware_product/cd87e849-5520-4601-86ef-5998ae6cde12
     method: GET
   response:
-    body: '{"alias":"RbJqbiCtgxVwwiexaoAcPPRtO","bios_firmware":"cklDuNjZvuriBSHtpAKGiQuVq","cpu_num":0,"cpu_type":"clmhxFxElLDctiiDlgKmNPvRM","created":"2020-01-13T23:16:22.916095Z","dimms_num":0,"generation_name":null,"hardware_vendor_id":"69b8ba60-3134-4355-bda1-99930d51dc37","hba_firmware":null,"id":"687be698-32a7-42f0-a669-0751d851563c","legacy_product_name":null,"name":"ZRloivsvIVzSZhaYBZHcsrnMh","nics_num":0,"nvme_ssd_num":0,"nvme_ssd_size":null,"nvme_ssd_slots":null,"prefix":null,"psu_total":0,"purpose":"EpxbsjfFxQJkBRlmPDqjFDdoz","rack_unit_size":1,"raid_lun_num":0,"ram_total":0,"sas_hdd_num":0,"sas_hdd_size":null,"sas_hdd_slots":null,"sas_ssd_num":0,"sas_ssd_size":null,"sas_ssd_slots":null,"sata_hdd_num":0,"sata_hdd_size":null,"sata_hdd_slots":null,"sata_ssd_num":0,"sata_ssd_size":null,"sata_ssd_slots":null,"sku":"AWFiqyOSIjFfuxPiHprFQiQnw","specification":null,"updated":"2020-01-13T23:16:22.916095Z","usb_num":0,"validation_plan_id":"a30ab8b2-8a9e-4e51-8bb0-92862abd8b54"}'
+    body: '{"alias":"kzdrzOFbSzwABLXZJgiRbeCyZ","bios_firmware":"YBMTTKmRmcMJdeudbCHnLdWTA","cpu_num":0,"cpu_type":"IjGVEsUTFgtcqCgykUYFkzSlh","created":"2020-01-26T19:04:28.239898Z","dimms_num":0,"generation_name":null,"hardware_vendor_id":"3d28519c-66c8-4342-8220-4e1cae887e2d","hba_firmware":null,"id":"cd87e849-5520-4601-86ef-5998ae6cde12","legacy_product_name":null,"name":"dpVmuHtPowtbsWxgeQGGhDxzq","nics_num":0,"nvme_ssd_num":0,"nvme_ssd_size":null,"nvme_ssd_slots":null,"prefix":null,"psu_total":0,"purpose":"aqjoVIMEkFxHTVJUbjbuQOjnq","rack_unit_size":1,"raid_lun_num":0,"ram_total":0,"sas_hdd_num":0,"sas_hdd_size":null,"sas_hdd_slots":null,"sas_ssd_num":0,"sas_ssd_size":null,"sas_ssd_slots":null,"sata_hdd_num":0,"sata_hdd_size":null,"sata_hdd_slots":null,"sata_ssd_num":0,"sata_ssd_size":null,"sata_ssd_slots":null,"sku":"kCKOViIEFgkEhdhcQFxItjUmb","specification":null,"updated":"2020-01-26T19:04:28.239898Z","usb_num":0,"validation_plan_id":"a30ab8b2-8a9e-4e51-8bb0-92862abd8b54"}'
     headers:
       Cache-Control:
       - no-cache
@@ -436,23 +462,23 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:22 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Location:
-      - /hardware_product/687be698-32a7-42f0-a669-0751d851563c
+      - /hardware_product/cd87e849-5520-4601-86ef-5998ae6cde12
       Request-Id:
-      - 2CtK2fuXam9r
+      - mfeqoXXxDNPO
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - 2CtK2fuXam9r
+      - mfeqoXXxDNPO
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"admins":[{"email":"conch@example.com"}],"description":"REPXnnboTyMAjyhHzyBrWQFFN","name":"wXPfktdFkuezdJMuLEccFqjJa"}
+      {"admins":[{"email":"conch@example.com"}],"description":"AMhZHoxzPwNZsyYmcTflWMKqY","name":"aQsXFjCLcMZdOKGwPLDAuldld"}
     form: {}
     headers:
       Content-Type:
@@ -469,15 +495,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Mon, 13 Jan 2020 23:16:22 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Location:
-      - /build/06a43ede-569e-4217-93b4-5855fba8ac86
+      - /build/2a089cd3-a9c3-4c38-be7a-e04e1c36706a
       Request-Id:
-      - aNG5oKbpNs3S
+      - 3wX2gtaUCHUw
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - aNG5oKbpNs3S
+      - 3wX2gtaUCHUw
     status: 303 See Other
     code: 303
     duration: ""
@@ -491,10 +517,10 @@ interactions:
       - http://10.51.54.42:5000/build
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/build/06a43ede-569e-4217-93b4-5855fba8ac86
+    url: http://10.51.54.42:5000/build/2a089cd3-a9c3-4c38-be7a-e04e1c36706a
     method: GET
   response:
-    body: '{"admins":[{"email":"conch@example.com","id":"1ebc992d-ced6-47fa-be0c-3f966a9eb42f","name":"Kosh"}],"completed":null,"completed_user":null,"created":"2020-01-13T23:16:22.970213Z","description":"REPXnnboTyMAjyhHzyBrWQFFN","id":"06a43ede-569e-4217-93b4-5855fba8ac86","name":"wXPfktdFkuezdJMuLEccFqjJa","started":null}'
+    body: '{"admins":[{"email":"conch@example.com","id":"1ebc992d-ced6-47fa-be0c-3f966a9eb42f","name":"Kosh"}],"completed":null,"completed_user":null,"created":"2020-01-26T19:04:28.289251Z","description":"AMhZHoxzPwNZsyYmcTflWMKqY","id":"2a089cd3-a9c3-4c38-be7a-e04e1c36706a","name":"aQsXFjCLcMZdOKGwPLDAuldld","started":null}'
     headers:
       Cache-Control:
       - no-cache
@@ -503,21 +529,21 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:23 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Request-Id:
-      - rM9PDn46Xw9d
+      - c3im2cDU7wCy
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - rM9PDn46Xw9d
+      - c3im2cDU7wCy
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"build_id":"06a43ede-569e-4217-93b4-5855fba8ac86","datacenter_room_id":"52ec7cb8-c954-4416-be38-d1b21766102e","name":"smxdjWMQbjcgavWkPuoiRzKhZ","phase":"integration","rack_role_id":"9b6e660f-0dd7-4755-951b-0872fa9b9669"}
+      {"build_id":"2a089cd3-a9c3-4c38-be7a-e04e1c36706a","datacenter_room_id":"7facfdc8-4155-4a68-9f28-2ce6b72f1d84","name":"gbOLAevgQXeOSzVeuqdsOCoZT","phase":"integration","rack_role_id":"7c795de7-9ac6-4bc2-aaca-9ff0e2a99ef0"}
     form: {}
     headers:
       Content-Type:
@@ -534,15 +560,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Mon, 13 Jan 2020 23:16:23 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Location:
-      - /rack/d87673d7-1771-4ae8-966d-343a9d6d8ba1
+      - /rack/bca95573-9ca0-4dc1-adc5-6a608c8227d2
       Request-Id:
-      - 7fsfkp8+mUUs
+      - B8DxwdR1pTZ1
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - 7fsfkp8+mUUs
+      - B8DxwdR1pTZ1
     status: 303 See Other
     code: 303
     duration: ""
@@ -556,10 +582,10 @@ interactions:
       - http://10.51.54.42:5000/rack
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/rack/d87673d7-1771-4ae8-966d-343a9d6d8ba1
+    url: http://10.51.54.42:5000/rack/bca95573-9ca0-4dc1-adc5-6a608c8227d2
     method: GET
   response:
-    body: '{"asset_tag":null,"build_id":"06a43ede-569e-4217-93b4-5855fba8ac86","build_name":"wXPfktdFkuezdJMuLEccFqjJa","created":"2020-01-13T23:16:23.033332Z","datacenter_room_alias":"cAGSLmBFBqjeUzknwoJwQpNMd","datacenter_room_id":"52ec7cb8-c954-4416-be38-d1b21766102e","full_rack_name":"EiKkKbgXjdswqZMzIYcDKMxQE:smxdjWMQbjcgavWkPuoiRzKhZ","id":"d87673d7-1771-4ae8-966d-343a9d6d8ba1","name":"smxdjWMQbjcgavWkPuoiRzKhZ","phase":"integration","rack_role_id":"9b6e660f-0dd7-4755-951b-0872fa9b9669","rack_role_name":"fFORUxYSaMDydfplzVwbnxfwv","serial_number":null,"updated":"2020-01-13T23:16:23.033332Z"}'
+    body: '{"asset_tag":null,"build_id":"2a089cd3-a9c3-4c38-be7a-e04e1c36706a","build_name":"aQsXFjCLcMZdOKGwPLDAuldld","created":"2020-01-26T19:04:28.356986Z","datacenter_room_alias":"vjdBBzhinOfupWTAsEKOvwGew","datacenter_room_id":"7facfdc8-4155-4a68-9f28-2ce6b72f1d84","full_rack_name":"OuzjBCPvhKBFhyRpMGYglHBfi:gbOLAevgQXeOSzVeuqdsOCoZT","id":"bca95573-9ca0-4dc1-adc5-6a608c8227d2","name":"gbOLAevgQXeOSzVeuqdsOCoZT","phase":"integration","rack_role_id":"7c795de7-9ac6-4bc2-aaca-9ff0e2a99ef0","rack_role_name":"ZHUfcaVHyETwvBjCbSzrvORQb","serial_number":null,"updated":"2020-01-26T19:04:28.356986Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -568,17 +594,17 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:23 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Location:
-      - /rack/d87673d7-1771-4ae8-966d-343a9d6d8ba1
+      - /rack/bca95573-9ca0-4dc1-adc5-6a608c8227d2
       Request-Id:
-      - 4/OO/ILM3YD6
+      - iTw7q6l2+1q3
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - 4/OO/ILM3YD6
+      - iTw7q6l2+1q3
     status: 200 OK
     code: 200
     duration: ""
@@ -588,10 +614,10 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/rack_role/9b6e660f-0dd7-4755-951b-0872fa9b9669
+    url: http://10.51.54.42:5000/rack_role/7c795de7-9ac6-4bc2-aaca-9ff0e2a99ef0
     method: GET
   response:
-    body: '{"created":"2020-01-13T23:16:22.637624Z","id":"9b6e660f-0dd7-4755-951b-0872fa9b9669","name":"fFORUxYSaMDydfplzVwbnxfwv","rack_size":60,"updated":"2020-01-13T23:16:22.637624Z"}'
+    body: '{"created":"2020-01-26T19:04:27.963266Z","id":"7c795de7-9ac6-4bc2-aaca-9ff0e2a99ef0","name":"ZHUfcaVHyETwvBjCbSzrvORQb","rack_size":60,"updated":"2020-01-26T19:04:27.963266Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -600,15 +626,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:23 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Request-Id:
-      - ubPtwLPCVU4T
+      - MaLAen5l28+d
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - ubPtwLPCVU4T
+      - MaLAen5l28+d
     status: 200 OK
     code: 200
     duration: ""
@@ -618,10 +644,10 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/rack/d87673d7-1771-4ae8-966d-343a9d6d8ba1
+    url: http://10.51.54.42:5000/rack/bca95573-9ca0-4dc1-adc5-6a608c8227d2
     method: GET
   response:
-    body: '{"asset_tag":null,"build_id":"06a43ede-569e-4217-93b4-5855fba8ac86","build_name":"wXPfktdFkuezdJMuLEccFqjJa","created":"2020-01-13T23:16:23.033332Z","datacenter_room_alias":"cAGSLmBFBqjeUzknwoJwQpNMd","datacenter_room_id":"52ec7cb8-c954-4416-be38-d1b21766102e","full_rack_name":"EiKkKbgXjdswqZMzIYcDKMxQE:smxdjWMQbjcgavWkPuoiRzKhZ","id":"d87673d7-1771-4ae8-966d-343a9d6d8ba1","name":"smxdjWMQbjcgavWkPuoiRzKhZ","phase":"integration","rack_role_id":"9b6e660f-0dd7-4755-951b-0872fa9b9669","rack_role_name":"fFORUxYSaMDydfplzVwbnxfwv","serial_number":null,"updated":"2020-01-13T23:16:23.033332Z"}'
+    body: '{"asset_tag":null,"build_id":"2a089cd3-a9c3-4c38-be7a-e04e1c36706a","build_name":"aQsXFjCLcMZdOKGwPLDAuldld","created":"2020-01-26T19:04:28.356986Z","datacenter_room_alias":"vjdBBzhinOfupWTAsEKOvwGew","datacenter_room_id":"7facfdc8-4155-4a68-9f28-2ce6b72f1d84","full_rack_name":"OuzjBCPvhKBFhyRpMGYglHBfi:gbOLAevgQXeOSzVeuqdsOCoZT","id":"bca95573-9ca0-4dc1-adc5-6a608c8227d2","name":"gbOLAevgQXeOSzVeuqdsOCoZT","phase":"integration","rack_role_id":"7c795de7-9ac6-4bc2-aaca-9ff0e2a99ef0","rack_role_name":"ZHUfcaVHyETwvBjCbSzrvORQb","serial_number":null,"updated":"2020-01-26T19:04:28.356986Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -630,17 +656,17 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:23 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Location:
-      - /rack/d87673d7-1771-4ae8-966d-343a9d6d8ba1
+      - /rack/bca95573-9ca0-4dc1-adc5-6a608c8227d2
       Request-Id:
-      - 1gvZG7x9/dhk
+      - Q0ButRl319N8
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - 1gvZG7x9/dhk
+      - Q0ButRl319N8
     status: 200 OK
     code: 200
     duration: ""
@@ -650,10 +676,10 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/rack_role/9b6e660f-0dd7-4755-951b-0872fa9b9669
+    url: http://10.51.54.42:5000/rack_role/7c795de7-9ac6-4bc2-aaca-9ff0e2a99ef0
     method: GET
   response:
-    body: '{"created":"2020-01-13T23:16:22.637624Z","id":"9b6e660f-0dd7-4755-951b-0872fa9b9669","name":"fFORUxYSaMDydfplzVwbnxfwv","rack_size":60,"updated":"2020-01-13T23:16:22.637624Z"}'
+    body: '{"created":"2020-01-26T19:04:27.963266Z","id":"7c795de7-9ac6-4bc2-aaca-9ff0e2a99ef0","name":"ZHUfcaVHyETwvBjCbSzrvORQb","rack_size":60,"updated":"2020-01-26T19:04:27.963266Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -662,15 +688,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:23 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Request-Id:
-      - qpkp8JQww5OS
+      - XDpC6/W0Lo/I
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - qpkp8JQww5OS
+      - XDpC6/W0Lo/I
     status: 200 OK
     code: 200
     duration: ""
@@ -680,10 +706,10 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/room/52ec7cb8-c954-4416-be38-d1b21766102e
+    url: http://10.51.54.42:5000/room/7facfdc8-4155-4a68-9f28-2ce6b72f1d84
     method: GET
   response:
-    body: '{"alias":"cAGSLmBFBqjeUzknwoJwQpNMd","az":"CvChoGaoYtibzraFdzWNcnWtw","created":"2020-01-13T23:16:22.722486Z","datacenter_id":"4361c5ba-6be1-4047-872c-eaea4c3177c5","id":"52ec7cb8-c954-4416-be38-d1b21766102e","updated":"2020-01-13T23:16:22.722486Z","vendor_name":"EiKkKbgXjdswqZMzIYcDKMxQE"}'
+    body: '{"alias":"vjdBBzhinOfupWTAsEKOvwGew","az":"AMfKdCbXyumqdNdnHVylqSswg","created":"2020-01-26T19:04:28.041112Z","datacenter_id":"7833a223-1395-4541-a471-d91d7ba846ab","id":"7facfdc8-4155-4a68-9f28-2ce6b72f1d84","updated":"2020-01-26T19:04:28.041112Z","vendor_name":"OuzjBCPvhKBFhyRpMGYglHBfi"}'
     headers:
       Cache-Control:
       - no-cache
@@ -692,17 +718,17 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:23 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Location:
-      - /room/52ec7cb8-c954-4416-be38-d1b21766102e
+      - /room/7facfdc8-4155-4a68-9f28-2ce6b72f1d84
       Request-Id:
-      - rCcrTq9GZfyp
+      - SBKPJqjxeG4i
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - rCcrTq9GZfyp
+      - SBKPJqjxeG4i
     status: 200 OK
     code: 200
     duration: ""
@@ -712,7 +738,7 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/rack/d87673d7-1771-4ae8-966d-343a9d6d8ba1/layout
+    url: http://10.51.54.42:5000/rack/bca95573-9ca0-4dc1-adc5-6a608c8227d2/layout
     method: GET
   response:
     body: '[]'
@@ -724,23 +750,23 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:23 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Location:
-      - /rack/d87673d7-1771-4ae8-966d-343a9d6d8ba1/layout
+      - /rack/bca95573-9ca0-4dc1-adc5-6a608c8227d2/layout
       Request-Id:
-      - ZvGOg/qDevEL
+      - 3RphLu/ynYqI
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - ZvGOg/qDevEL
+      - 3RphLu/ynYqI
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"hardware_product_id":"687be698-32a7-42f0-a669-0751d851563c","rack_id":"d87673d7-1771-4ae8-966d-343a9d6d8ba1","rack_unit_start":1}
+      {"hardware_product_id":"cd87e849-5520-4601-86ef-5998ae6cde12","rack_id":"bca95573-9ca0-4dc1-adc5-6a608c8227d2","rack_unit_start":1}
     form: {}
     headers:
       Content-Type:
@@ -757,15 +783,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Mon, 13 Jan 2020 23:16:23 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Location:
-      - /layout/f3ca18f7-e38e-4920-a225-ec479fa54b63
+      - /layout/35bbf62f-1fbf-40c2-97af-485ab568ae99
       Request-Id:
-      - hy0LUV3joBm3
+      - RGinlFOtuFhY
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - hy0LUV3joBm3
+      - RGinlFOtuFhY
     status: 303 See Other
     code: 303
     duration: ""
@@ -779,10 +805,10 @@ interactions:
       - http://10.51.54.42:5000/layout
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/layout/f3ca18f7-e38e-4920-a225-ec479fa54b63
+    url: http://10.51.54.42:5000/layout/35bbf62f-1fbf-40c2-97af-485ab568ae99
     method: GET
   response:
-    body: '{"created":"2020-01-13T23:16:23.214713Z","hardware_product_id":"687be698-32a7-42f0-a669-0751d851563c","id":"f3ca18f7-e38e-4920-a225-ec479fa54b63","rack_id":"d87673d7-1771-4ae8-966d-343a9d6d8ba1","rack_name":"EiKkKbgXjdswqZMzIYcDKMxQE:smxdjWMQbjcgavWkPuoiRzKhZ","rack_unit_size":1,"rack_unit_start":1,"sku":"AWFiqyOSIjFfuxPiHprFQiQnw","updated":"2020-01-13T23:16:23.214713Z"}'
+    body: '{"created":"2020-01-26T19:04:28.530904Z","hardware_product_id":"cd87e849-5520-4601-86ef-5998ae6cde12","id":"35bbf62f-1fbf-40c2-97af-485ab568ae99","rack_id":"bca95573-9ca0-4dc1-adc5-6a608c8227d2","rack_name":"OuzjBCPvhKBFhyRpMGYglHBfi:gbOLAevgQXeOSzVeuqdsOCoZT","rack_unit_size":1,"rack_unit_start":1,"sku":"kCKOViIEFgkEhdhcQFxItjUmb","updated":"2020-01-26T19:04:28.530904Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -791,23 +817,23 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:23 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Location:
-      - /layout/f3ca18f7-e38e-4920-a225-ec479fa54b63
+      - /layout/35bbf62f-1fbf-40c2-97af-485ab568ae99
       Request-Id:
-      - 0b0dz1nIt9v8
+      - /4UVPxwvbuMn
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - 0b0dz1nIt9v8
+      - /4UVPxwvbuMn
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"hardware_product_id":"01390cbe-7daa-4a4e-b005-d36c9972bfdd","rack_id":"d87673d7-1771-4ae8-966d-343a9d6d8ba1","rack_unit_start":2}
+      {"hardware_product_id":"4d97ab05-0d97-47aa-862d-82bb2ee0468a","rack_id":"bca95573-9ca0-4dc1-adc5-6a608c8227d2","rack_unit_start":2}
     form: {}
     headers:
       Content-Type:
@@ -824,15 +850,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Mon, 13 Jan 2020 23:16:23 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Location:
-      - /layout/61b719e6-5fce-4ea7-9f1e-e5fd1fe1087d
+      - /layout/d0453671-06f8-43b7-a435-d9bc46740c67
       Request-Id:
-      - D61zIqAxsAC6
+      - 2Qdcr2mGr4aG
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - D61zIqAxsAC6
+      - 2Qdcr2mGr4aG
     status: 303 See Other
     code: 303
     duration: ""
@@ -846,10 +872,10 @@ interactions:
       - http://10.51.54.42:5000/layout
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/layout/61b719e6-5fce-4ea7-9f1e-e5fd1fe1087d
+    url: http://10.51.54.42:5000/layout/d0453671-06f8-43b7-a435-d9bc46740c67
     method: GET
   response:
-    body: '{"created":"2020-01-13T23:16:23.278704Z","hardware_product_id":"01390cbe-7daa-4a4e-b005-d36c9972bfdd","id":"61b719e6-5fce-4ea7-9f1e-e5fd1fe1087d","rack_id":"d87673d7-1771-4ae8-966d-343a9d6d8ba1","rack_name":"EiKkKbgXjdswqZMzIYcDKMxQE:smxdjWMQbjcgavWkPuoiRzKhZ","rack_unit_size":1,"rack_unit_start":2,"sku":"ueiumFKFIPGkCCRJEDgJhFtrr","updated":"2020-01-13T23:16:23.278704Z"}'
+    body: '{"created":"2020-01-26T19:04:28.596937Z","hardware_product_id":"4d97ab05-0d97-47aa-862d-82bb2ee0468a","id":"d0453671-06f8-43b7-a435-d9bc46740c67","rack_id":"bca95573-9ca0-4dc1-adc5-6a608c8227d2","rack_name":"OuzjBCPvhKBFhyRpMGYglHBfi:gbOLAevgQXeOSzVeuqdsOCoZT","rack_unit_size":1,"rack_unit_start":2,"sku":"qDwDpLdrLFrPEqjOOUrmyGirY","updated":"2020-01-26T19:04:28.596937Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -858,17 +884,17 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:23 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Location:
-      - /layout/61b719e6-5fce-4ea7-9f1e-e5fd1fe1087d
+      - /layout/d0453671-06f8-43b7-a435-d9bc46740c67
       Request-Id:
-      - gT5sHB8K2Nve
+      - ZsDc+jhMWIhV
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - gT5sHB8K2Nve
+      - ZsDc+jhMWIhV
     status: 200 OK
     code: 200
     duration: ""
@@ -878,10 +904,10 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/rack/d87673d7-1771-4ae8-966d-343a9d6d8ba1/layout
+    url: http://10.51.54.42:5000/rack/bca95573-9ca0-4dc1-adc5-6a608c8227d2/layout
     method: GET
   response:
-    body: '[{"created":"2020-01-13T23:16:23.214713Z","hardware_product_id":"687be698-32a7-42f0-a669-0751d851563c","id":"f3ca18f7-e38e-4920-a225-ec479fa54b63","rack_id":"d87673d7-1771-4ae8-966d-343a9d6d8ba1","rack_name":"EiKkKbgXjdswqZMzIYcDKMxQE:smxdjWMQbjcgavWkPuoiRzKhZ","rack_unit_size":1,"rack_unit_start":1,"sku":"AWFiqyOSIjFfuxPiHprFQiQnw","updated":"2020-01-13T23:16:23.214713Z"},{"created":"2020-01-13T23:16:23.278704Z","hardware_product_id":"01390cbe-7daa-4a4e-b005-d36c9972bfdd","id":"61b719e6-5fce-4ea7-9f1e-e5fd1fe1087d","rack_id":"d87673d7-1771-4ae8-966d-343a9d6d8ba1","rack_name":"EiKkKbgXjdswqZMzIYcDKMxQE:smxdjWMQbjcgavWkPuoiRzKhZ","rack_unit_size":1,"rack_unit_start":2,"sku":"ueiumFKFIPGkCCRJEDgJhFtrr","updated":"2020-01-13T23:16:23.278704Z"}]'
+    body: '[{"created":"2020-01-26T19:04:28.530904Z","hardware_product_id":"cd87e849-5520-4601-86ef-5998ae6cde12","id":"35bbf62f-1fbf-40c2-97af-485ab568ae99","rack_id":"bca95573-9ca0-4dc1-adc5-6a608c8227d2","rack_name":"OuzjBCPvhKBFhyRpMGYglHBfi:gbOLAevgQXeOSzVeuqdsOCoZT","rack_unit_size":1,"rack_unit_start":1,"sku":"kCKOViIEFgkEhdhcQFxItjUmb","updated":"2020-01-26T19:04:28.530904Z"},{"created":"2020-01-26T19:04:28.596937Z","hardware_product_id":"4d97ab05-0d97-47aa-862d-82bb2ee0468a","id":"d0453671-06f8-43b7-a435-d9bc46740c67","rack_id":"bca95573-9ca0-4dc1-adc5-6a608c8227d2","rack_name":"OuzjBCPvhKBFhyRpMGYglHBfi:gbOLAevgQXeOSzVeuqdsOCoZT","rack_unit_size":1,"rack_unit_start":2,"sku":"qDwDpLdrLFrPEqjOOUrmyGirY","updated":"2020-01-26T19:04:28.596937Z"}]'
     headers:
       Cache-Control:
       - no-cache
@@ -890,17 +916,17 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:23 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Location:
-      - /rack/d87673d7-1771-4ae8-966d-343a9d6d8ba1/layout
+      - /rack/bca95573-9ca0-4dc1-adc5-6a608c8227d2/layout
       Request-Id:
-      - gcTVMHVAIXGZ
+      - Q5cAe11DtfJJ
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - gcTVMHVAIXGZ
+      - Q5cAe11DtfJJ
     status: 200 OK
     code: 200
     duration: ""
@@ -910,10 +936,10 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/rack/d87673d7-1771-4ae8-966d-343a9d6d8ba1/layout
+    url: http://10.51.54.42:5000/rack/bca95573-9ca0-4dc1-adc5-6a608c8227d2/layout
     method: GET
   response:
-    body: '[{"created":"2020-01-13T23:16:23.214713Z","hardware_product_id":"687be698-32a7-42f0-a669-0751d851563c","id":"f3ca18f7-e38e-4920-a225-ec479fa54b63","rack_id":"d87673d7-1771-4ae8-966d-343a9d6d8ba1","rack_name":"EiKkKbgXjdswqZMzIYcDKMxQE:smxdjWMQbjcgavWkPuoiRzKhZ","rack_unit_size":1,"rack_unit_start":1,"sku":"AWFiqyOSIjFfuxPiHprFQiQnw","updated":"2020-01-13T23:16:23.214713Z"},{"created":"2020-01-13T23:16:23.278704Z","hardware_product_id":"01390cbe-7daa-4a4e-b005-d36c9972bfdd","id":"61b719e6-5fce-4ea7-9f1e-e5fd1fe1087d","rack_id":"d87673d7-1771-4ae8-966d-343a9d6d8ba1","rack_name":"EiKkKbgXjdswqZMzIYcDKMxQE:smxdjWMQbjcgavWkPuoiRzKhZ","rack_unit_size":1,"rack_unit_start":2,"sku":"ueiumFKFIPGkCCRJEDgJhFtrr","updated":"2020-01-13T23:16:23.278704Z"}]'
+    body: '[{"created":"2020-01-26T19:04:28.530904Z","hardware_product_id":"cd87e849-5520-4601-86ef-5998ae6cde12","id":"35bbf62f-1fbf-40c2-97af-485ab568ae99","rack_id":"bca95573-9ca0-4dc1-adc5-6a608c8227d2","rack_name":"OuzjBCPvhKBFhyRpMGYglHBfi:gbOLAevgQXeOSzVeuqdsOCoZT","rack_unit_size":1,"rack_unit_start":1,"sku":"kCKOViIEFgkEhdhcQFxItjUmb","updated":"2020-01-26T19:04:28.530904Z"},{"created":"2020-01-26T19:04:28.596937Z","hardware_product_id":"4d97ab05-0d97-47aa-862d-82bb2ee0468a","id":"d0453671-06f8-43b7-a435-d9bc46740c67","rack_id":"bca95573-9ca0-4dc1-adc5-6a608c8227d2","rack_name":"OuzjBCPvhKBFhyRpMGYglHBfi:gbOLAevgQXeOSzVeuqdsOCoZT","rack_unit_size":1,"rack_unit_start":2,"sku":"qDwDpLdrLFrPEqjOOUrmyGirY","updated":"2020-01-26T19:04:28.596937Z"}]'
     headers:
       Cache-Control:
       - no-cache
@@ -922,17 +948,17 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:23 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Location:
-      - /rack/d87673d7-1771-4ae8-966d-343a9d6d8ba1/layout
+      - /rack/bca95573-9ca0-4dc1-adc5-6a608c8227d2/layout
       Request-Id:
-      - g6AsHnqwVw+U
+      - LVX3660fo3iT
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - g6AsHnqwVw+U
+      - LVX3660fo3iT
     status: 200 OK
     code: 200
     duration: ""
@@ -942,7 +968,7 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/layout/f3ca18f7-e38e-4920-a225-ec479fa54b63
+    url: http://10.51.54.42:5000/layout/35bbf62f-1fbf-40c2-97af-485ab568ae99
     method: DELETE
   response:
     body: ""
@@ -950,13 +976,13 @@ interactions:
       Cache-Control:
       - no-cache
       Date:
-      - Mon, 13 Jan 2020 23:16:23 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Request-Id:
-      - EzqMWqqpHhV0
+      - i5IEvFrzuJhv
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - EzqMWqqpHhV0
+      - i5IEvFrzuJhv
     status: 204 No Content
     code: 204
     duration: ""
@@ -966,7 +992,7 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/layout/61b719e6-5fce-4ea7-9f1e-e5fd1fe1087d
+    url: http://10.51.54.42:5000/layout/d0453671-06f8-43b7-a435-d9bc46740c67
     method: DELETE
   response:
     body: ""
@@ -974,13 +1000,13 @@ interactions:
       Cache-Control:
       - no-cache
       Date:
-      - Mon, 13 Jan 2020 23:16:23 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Request-Id:
-      - rLIoOr12vaFV
+      - iT08B5K1AJZu
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - rLIoOr12vaFV
+      - iT08B5K1AJZu
     status: 204 No Content
     code: 204
     duration: ""
@@ -990,7 +1016,7 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/rack/d87673d7-1771-4ae8-966d-343a9d6d8ba1
+    url: http://10.51.54.42:5000/rack/bca95573-9ca0-4dc1-adc5-6a608c8227d2
     method: DELETE
   response:
     body: ""
@@ -998,19 +1024,19 @@ interactions:
       Cache-Control:
       - no-cache
       Date:
-      - Mon, 13 Jan 2020 23:16:23 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Request-Id:
-      - McIeo7l21RYP
+      - rRMtWX3hQaot
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - McIeo7l21RYP
+      - rRMtWX3hQaot
     status: 204 No Content
     code: 204
     duration: ""
 - request:
     body: |
-      {"build_id":"06a43ede-569e-4217-93b4-5855fba8ac86","datacenter_room_id":"52ec7cb8-c954-4416-be38-d1b21766102e","name":"wEVzVWllBTZGInHcJpOuTXnGa","phase":"integration","rack_role_id":"9b6e660f-0dd7-4755-951b-0872fa9b9669"}
+      {"build_id":"2a089cd3-a9c3-4c38-be7a-e04e1c36706a","datacenter_room_id":"7facfdc8-4155-4a68-9f28-2ce6b72f1d84","name":"IsQZkOvCDvgXVktirYJznAkaL","phase":"integration","rack_role_id":"7c795de7-9ac6-4bc2-aaca-9ff0e2a99ef0"}
     form: {}
     headers:
       Content-Type:
@@ -1027,15 +1053,15 @@ interactions:
       Content-Length:
       - "0"
       Date:
-      - Mon, 13 Jan 2020 23:16:23 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Location:
-      - /rack/7be9603b-4da0-4c97-a5be-8d11d6ae93b2
+      - /rack/1a66390c-0aef-472c-9db8-2a28e55d7c18
       Request-Id:
-      - /zvmeJ4jTAV+
+      - OjejwIQRJ0U9
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - /zvmeJ4jTAV+
+      - OjejwIQRJ0U9
     status: 303 See Other
     code: 303
     duration: ""
@@ -1049,10 +1075,10 @@ interactions:
       - http://10.51.54.42:5000/rack
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/rack/7be9603b-4da0-4c97-a5be-8d11d6ae93b2
+    url: http://10.51.54.42:5000/rack/1a66390c-0aef-472c-9db8-2a28e55d7c18
     method: GET
   response:
-    body: '{"asset_tag":null,"build_id":"06a43ede-569e-4217-93b4-5855fba8ac86","build_name":"wXPfktdFkuezdJMuLEccFqjJa","created":"2020-01-13T23:16:23.471424Z","datacenter_room_alias":"cAGSLmBFBqjeUzknwoJwQpNMd","datacenter_room_id":"52ec7cb8-c954-4416-be38-d1b21766102e","full_rack_name":"EiKkKbgXjdswqZMzIYcDKMxQE:wEVzVWllBTZGInHcJpOuTXnGa","id":"7be9603b-4da0-4c97-a5be-8d11d6ae93b2","name":"wEVzVWllBTZGInHcJpOuTXnGa","phase":"integration","rack_role_id":"9b6e660f-0dd7-4755-951b-0872fa9b9669","rack_role_name":"fFORUxYSaMDydfplzVwbnxfwv","serial_number":null,"updated":"2020-01-13T23:16:23.471424Z"}'
+    body: '{"asset_tag":null,"build_id":"2a089cd3-a9c3-4c38-be7a-e04e1c36706a","build_name":"aQsXFjCLcMZdOKGwPLDAuldld","created":"2020-01-26T19:04:28.768430Z","datacenter_room_alias":"vjdBBzhinOfupWTAsEKOvwGew","datacenter_room_id":"7facfdc8-4155-4a68-9f28-2ce6b72f1d84","full_rack_name":"OuzjBCPvhKBFhyRpMGYglHBfi:IsQZkOvCDvgXVktirYJznAkaL","id":"1a66390c-0aef-472c-9db8-2a28e55d7c18","name":"IsQZkOvCDvgXVktirYJznAkaL","phase":"integration","rack_role_id":"7c795de7-9ac6-4bc2-aaca-9ff0e2a99ef0","rack_role_name":"ZHUfcaVHyETwvBjCbSzrvORQb","serial_number":null,"updated":"2020-01-26T19:04:28.768430Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -1061,17 +1087,17 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:23 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Location:
-      - /rack/7be9603b-4da0-4c97-a5be-8d11d6ae93b2
+      - /rack/1a66390c-0aef-472c-9db8-2a28e55d7c18
       Request-Id:
-      - Id0lmrh+IMt0
+      - 9jcqMTo4yvAH
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - Id0lmrh+IMt0
+      - 9jcqMTo4yvAH
     status: 200 OK
     code: 200
     duration: ""
@@ -1081,10 +1107,10 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/rack_role/9b6e660f-0dd7-4755-951b-0872fa9b9669
+    url: http://10.51.54.42:5000/rack_role/7c795de7-9ac6-4bc2-aaca-9ff0e2a99ef0
     method: GET
   response:
-    body: '{"created":"2020-01-13T23:16:22.637624Z","id":"9b6e660f-0dd7-4755-951b-0872fa9b9669","name":"fFORUxYSaMDydfplzVwbnxfwv","rack_size":60,"updated":"2020-01-13T23:16:22.637624Z"}'
+    body: '{"created":"2020-01-26T19:04:27.963266Z","id":"7c795de7-9ac6-4bc2-aaca-9ff0e2a99ef0","name":"ZHUfcaVHyETwvBjCbSzrvORQb","rack_size":60,"updated":"2020-01-26T19:04:27.963266Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -1093,15 +1119,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 Jan 2020 23:16:23 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Request-Id:
-      - V24LVCElR7zy
+      - msuBEwJVKflx
       Server:
       - Mojolicious (Perl)
       X-Conch-Api:
       - v3.0.0-b4-0-gb99fbfff
       X-Request-Id:
-      - V24LVCElR7zy
+      - msuBEwJVKflx
     status: 200 OK
     code: 200
     duration: ""
@@ -1111,7 +1137,7 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/rack/7be9603b-4da0-4c97-a5be-8d11d6ae93b2
+    url: http://10.51.54.42:5000/rack/1a66390c-0aef-472c-9db8-2a28e55d7c18
     method: DELETE
   response:
     body: ""
@@ -1119,13 +1145,13 @@ interactions:
       Cache-Control:
       - no-cache
       Date:
-      - Mon, 13 Jan 2020 23:16:23 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Request-Id:
-      - d4cv+xbQG9aM
+      - ww51X0YPDUna
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - d4cv+xbQG9aM
+      - ww51X0YPDUna
     status: 204 No Content
     code: 204
     duration: ""
@@ -1135,7 +1161,7 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/hardware_product/687be698-32a7-42f0-a669-0751d851563c
+    url: http://10.51.54.42:5000/hardware_product/cd87e849-5520-4601-86ef-5998ae6cde12
     method: DELETE
   response:
     body: ""
@@ -1143,13 +1169,13 @@ interactions:
       Cache-Control:
       - no-cache
       Date:
-      - Mon, 13 Jan 2020 23:16:23 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Request-Id:
-      - Qe7iINLBBucn
+      - 8Z/VaSizYrrc
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - Qe7iINLBBucn
+      - 8Z/VaSizYrrc
     status: 204 No Content
     code: 204
     duration: ""
@@ -1159,7 +1185,7 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/hardware_product/01390cbe-7daa-4a4e-b005-d36c9972bfdd
+    url: http://10.51.54.42:5000/hardware_product/4d97ab05-0d97-47aa-862d-82bb2ee0468a
     method: DELETE
   response:
     body: ""
@@ -1167,13 +1193,13 @@ interactions:
       Cache-Control:
       - no-cache
       Date:
-      - Mon, 13 Jan 2020 23:16:23 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Request-Id:
-      - j8tQSWrcQoGD
+      - PiMlCqijk5jb
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - j8tQSWrcQoGD
+      - PiMlCqijk5jb
     status: 204 No Content
     code: 204
     duration: ""
@@ -1183,7 +1209,7 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/hardware_vendor/MyNewVendor
+    url: http://10.51.54.42:5000/hardware_vendor/3d28519c-66c8-4342-8220-4e1cae887e2d
     method: DELETE
   response:
     body: ""
@@ -1191,13 +1217,13 @@ interactions:
       Cache-Control:
       - no-cache
       Date:
-      - Mon, 13 Jan 2020 23:16:23 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Request-Id:
-      - Ctg+cAJvu8Ee
+      - f+IRfQ8YIzw/
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - Ctg+cAJvu8Ee
+      - f+IRfQ8YIzw/
     status: 204 No Content
     code: 204
     duration: ""
@@ -1207,7 +1233,7 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/room/52ec7cb8-c954-4416-be38-d1b21766102e
+    url: http://10.51.54.42:5000/room/7facfdc8-4155-4a68-9f28-2ce6b72f1d84
     method: DELETE
   response:
     body: ""
@@ -1215,13 +1241,13 @@ interactions:
       Cache-Control:
       - no-cache
       Date:
-      - Mon, 13 Jan 2020 23:16:23 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Request-Id:
-      - XXw08OMbwVtJ
+      - zTNzjDVNesDF
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - XXw08OMbwVtJ
+      - zTNzjDVNesDF
     status: 204 No Content
     code: 204
     duration: ""
@@ -1231,7 +1257,7 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/dc/4361c5ba-6be1-4047-872c-eaea4c3177c5
+    url: http://10.51.54.42:5000/dc/7833a223-1395-4541-a471-d91d7ba846ab
     method: DELETE
   response:
     body: ""
@@ -1239,13 +1265,13 @@ interactions:
       Cache-Control:
       - no-cache
       Date:
-      - Mon, 13 Jan 2020 23:16:23 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Request-Id:
-      - JO4qwCLwNFne
+      - vATUZMCt5AUw
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - JO4qwCLwNFne
+      - vATUZMCt5AUw
     status: 204 No Content
     code: 204
     duration: ""
@@ -1255,7 +1281,7 @@ interactions:
     headers:
       User-Agent:
       - Conch/3.x-testing
-    url: http://10.51.54.42:5000/rack_role/9b6e660f-0dd7-4755-951b-0872fa9b9669
+    url: http://10.51.54.42:5000/rack_role/7c795de7-9ac6-4bc2-aaca-9ff0e2a99ef0
     method: DELETE
   response:
     body: ""
@@ -1263,13 +1289,13 @@ interactions:
       Cache-Control:
       - no-cache
       Date:
-      - Mon, 13 Jan 2020 23:16:23 GMT
+      - Sun, 26 Jan 2020 19:04:28 GMT
       Request-Id:
-      - BPQKH10fvy5E
+      - YYyTVzCtYI+9
       Server:
       - Mojolicious (Perl)
       X-Request-Id:
-      - BPQKH10fvy5E
+      - YYyTVzCtYI+9
     status: 204 No Content
     code: 204
     duration: ""

--- a/fixtures_test.go
+++ b/fixtures_test.go
@@ -83,11 +83,11 @@ func (f *Fixture) setupHardwareVendor() *Fixture {
 		return f
 	}
 
-	//	mock := newTestHardwareVendor()
-	f.hardwareVendor = API.Hardware().CreateVendor("MyNewVendor")
+	//mock := newTestHardwareVendor()
+	f.hardwareVendor = API.Hardware().FindOrCreateVendor("MyBigVendor")
 
 	return f.addReset(func() {
-		API.Hardware().DeleteVendor(f.hardwareVendor.Name)
+		API.Hardware().DeleteVendor(f.hardwareVendor.ID)
 	})
 }
 

--- a/hardware_integration_test.go
+++ b/hardware_integration_test.go
@@ -1,13 +1,14 @@
 package main
 
 import (
+	"strconv"
 	"testing"
+
+	cli "github.com/jawher/mow.cli"
+	"github.com/stretchr/testify/assert"
 )
 
-// the validations are currently hardcoded in every instance of conch
-// fixing that is on the slate for v3.1
-
-func TestHarwareProductAPIIntegration(t *testing.T) {
+func TestHarwareProductIntegration(t *testing.T) {
 	defer errorHandler()
 
 	setupAPIClient()
@@ -20,35 +21,100 @@ func TestHarwareProductAPIIntegration(t *testing.T) {
 	f.setupValidationPlan()
 	defer f.reset()
 
-	var testHardwareProduct HardwareProduct
+	t.Run("API", func(t *testing.T) {
+		var testHardwareProduct HardwareProduct
 
-	t.Run("create", func(t *testing.T) {
-		defer errorHandler()
-		mock := newTestHardwareProduct()
-		testHardwareProduct = API.Hardware().Create(
-			mock.Name,
-			mock.Alias,
-			f.hardwareVendor.ID,
-			mock.SKU,
-			mock.RackUnitSize,
-			f.validationPlan.ID,
-			mock.Purpose,
-			mock.BiosFirmware,
-			mock.CpuType,
-		)
-	})
-
-	/*	t.Run("get-all-products", func(t *testing.T) {
-			_ = API.Hardware().GetAllProducts()
+		t.Run("create", func(t *testing.T) {
+			defer errorHandler()
+			mock := newTestHardwareProduct()
+			testHardwareProduct = API.Hardware().Create(
+				mock.Name,
+				mock.Alias,
+				f.hardwareVendor.ID,
+				mock.SKU,
+				mock.RackUnitSize,
+				f.validationPlan.ID,
+				mock.Purpose,
+				mock.BiosFirmware,
+				mock.CpuType,
+			)
+			assert.NotNil(t, testHardwareProduct.ID)
 		})
-	*/
-	t.Run("get-product-by-name", func(t *testing.T) {
-		defer errorHandler()
-		_ = API.Hardware().GetProductByName(testHardwareProduct.Name)
+
+		t.Run("get all products", func(t *testing.T) {
+			got := API.Hardware().GetAllProducts()
+			assert.Equal(t, HardwareProducts{testHardwareProduct}, got)
+
+		})
+
+		t.Run("get product by name", func(t *testing.T) {
+			defer errorHandler()
+			got := API.Hardware().GetProductByName(testHardwareProduct.Name)
+			assert.Equal(t, testHardwareProduct, got)
+		})
+
+		t.Run("delete product", func(t *testing.T) {
+			defer errorHandler()
+			API.Hardware().Delete(testHardwareProduct.ID)
+			got := API.Hardware().GetAllProducts()
+			assert.Equal(t, HardwareProducts{}, got)
+		})
 	})
 
-	t.Run("delete", func(t *testing.T) {
-		defer errorHandler()
-		API.Hardware().Delete(testHardwareProduct.ID)
+	t.Run("cli", func(t *testing.T) {
+		mock := newTestHardwareProduct()
+		mock.SKU = "test-sku-001"
+		mock.Name = "Testy McTesterson"
+
+		cases := []struct {
+			name string
+			cli  []string
+			want string
+		}{
+			{
+				"create",
+				[]string{
+					"kosh", "hardware", "products", "create",
+					"--sku", mock.SKU,
+					"--name", mock.Name,
+					"--alias", mock.Alias,
+					"--vendor", f.hardwareVendor.Name,
+					"--rack-unit-size", strconv.Itoa(mock.RackUnitSize),
+					"--validation-plan", f.validationPlan.ID.String(),
+					"--purpose", mock.Purpose,
+					"--bios-firmware", mock.BiosFirmware,
+					"--cpu-type", mock.CpuType,
+				},
+				"\nID: 9ad55ceb-2eb7-4125-a492-3c595277b3e3\nName: Testy McTesterson\nSKU: test-sku-001\n\nCreated: 2020-01-26 19:04:27 +0000 UTC\nUpdated: 2020-01-26 19:04:27 +0000 UTC\n\n",
+			},
+			{
+				"products ls",
+				[]string{"kosh", "hardware", "products", "ls"},
+				"|    ID    |     SKU      |       NAME        |           ALIAS           |          PURPOSE          |           BIOS            |         CPU TYPE          |                VENDOR                |           VALIDATION PLAN            |               CREATED                |               UPDATED                |\n|----------|--------------|-------------------|---------------------------|---------------------------|---------------------------|---------------------------|--------------------------------------|--------------------------------------|--------------------------------------|--------------------------------------|\n| 9ad55ceb | test-sku-001 | Testy McTesterson | ujOmocHFAUuWZILajRAzVkeuO | FCYNIyfxlJtZmSIluDaoPNwRD | RcgHsdxbvsvNXWQMpuLchiLgH | FEkEUQAJTUIwzzxxHsXjxWJqN | 26df0913-5614-4fec-beb7-3514df2a9356 | a30ab8b2-8a9e-4e51-8bb0-92862abd8b54 | 2020-01-26 19:04:27.567389 +0000 UTC | 2020-01-26 19:04:27.567389 +0000 UTC |\n\n",
+			},
+			{
+				"product SKU get",
+				[]string{"kosh", "hardware", "product", mock.SKU, "get"},
+				"\nID: 9ad55ceb-2eb7-4125-a492-3c595277b3e3\nName: Testy McTesterson\nSKU: test-sku-001\n\nCreated: 2020-01-26 19:04:27 +0000 UTC\nUpdated: 2020-01-26 19:04:27 +0000 UTC\n\n",
+			},
+			{
+				"product SKU delete",
+				[]string{"kosh", "hardware", "product", mock.SKU, "rm"},
+				HardwareProducts{}.String() + "\n",
+			},
+		}
+
+		for _, cas := range cases {
+			defer errorHandler()
+			t.Run(cas.name, func(t *testing.T) {
+				defer errorHandler()
+				t.Logf("Testing %+v", cas.cli)
+				app := cli.App("kosh", "Command line interface for Conch")
+				initHardwareCli(app)
+				got := captureOutput(func() { app.Run(cas.cli) })
+				assert.Equal(t, cas.want, got)
+			})
+		}
 	})
+
 }

--- a/hardware_test.go
+++ b/hardware_test.go
@@ -104,7 +104,7 @@ func TestHardwareVendorDelete(t *testing.T) {
 	hv := newTestHardwareVendor()
 	h := API.Hardware()
 
-	h.DeleteVendor(hv.ID.String())
+	h.DeleteVendor(hv.ID)
 
 	assertRequestMethod(t, spy.requestMethod, "DELETE")
 	assertRequestCount(t, spy.requestCount, 1)

--- a/hardware_test.go
+++ b/hardware_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestHardwareProductCreate(t *testing.T) {
@@ -43,7 +45,7 @@ func TestHardwareProductCreate(t *testing.T) {
 	assertRequestCount(t, spy.requestCount, 1)
 	assertRequestPath(t, spy.requestPath, "/hardware_product")
 	assertRequestMethod(t, spy.requestMethod, "POST")
-	assertData(t, got, want)
+	assert.Equal(t, got, want)
 }
 
 func TestHardwareProductDelete(t *testing.T) {

--- a/organizations_test.go
+++ b/organizations_test.go
@@ -7,8 +7,9 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestOrganizationsGet(t *testing.T) {
@@ -37,7 +38,7 @@ func TestOrganizationsGet(t *testing.T) {
 			assertRequestMethod(t, spy.requestMethod, "GET")
 			assertRequestCount(t, spy.requestCount, i+1)
 			assertRequestPath(t, spy.requestPath, fmt.Sprintf("/organization/%s", org.ID))
-			assertData(t, got, org)
+			assert.Equal(t, got, org)
 		})
 	}
 
@@ -69,7 +70,7 @@ func TestOrganizationsGetByName(t *testing.T) {
 			assertRequestMethod(t, spy.requestMethod, "GET")
 			assertRequestCount(t, spy.requestCount, i+1)
 			assertRequestPath(t, spy.requestPath, fmt.Sprintf("/organization/%s", org.Name))
-			assertData(t, got, org)
+			assert.Equal(t, got, org)
 		})
 	}
 
@@ -93,7 +94,7 @@ func TestOrganizationsGetAll(t *testing.T) {
 
 	assertRequestCount(t, spy.requestCount, 1)
 	assertRequestPath(t, spy.requestPath, "/organization")
-	assertData(t, got, orgList)
+	assert.Equal(t, got, orgList)
 }
 
 func TestOrganizationsCreate(t *testing.T) {
@@ -123,7 +124,7 @@ func TestOrganizationsCreate(t *testing.T) {
 	}
 
 	// now let's check what we made in the server is what we got in the client
-	assertData(t, got, want)
+	assert.Equal(t, got, want)
 }
 
 func TestOrganizationsDelete(t *testing.T) {
@@ -169,7 +170,7 @@ func TestOrganizationsGetUsers(t *testing.T) {
 	assertRequestMethod(t, spy.requestMethod, "GET")
 	assertRequestCount(t, spy.requestCount, 1)
 	assertRequestPath(t, spy.requestPath, fmt.Sprintf("/organization/%s/user", org.ID))
-	assertData(t, got, userList)
+	assert.Equal(t, got, userList)
 }
 
 func TestOrganizationsAddUser(t *testing.T) {
@@ -253,12 +254,5 @@ func assertRequestCount(t *testing.T, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("Wrong number of requests, got %d wanted %d", got, want)
-	}
-}
-
-func assertData(t *testing.T, got, want interface{}) {
-	t.Helper()
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("Got wrong results, got %v wanted %v", got, want)
 	}
 }

--- a/racks.go
+++ b/racks.go
@@ -318,8 +318,8 @@ type RackLayoutSlot struct {
 	RackName          string    `json:"rack_name"`
 	SKU               string    `json:"sku"`
 	HardwareProductID uuid.UUID `json:"hardware_product_id" faker:"uuid"`
-	RackUnitStart     int       `json:"rack_unit_start", faker:"rack_unit_start"`
-	RackUnitSize      int       `json:"rack_unit_size", faker:"rack_unit_size"`
+	RackUnitStart     int       `json:"rack_unit_start" faker:"rack_unit_start"`
+	RackUnitSize      int       `json:"rack_unit_size" faker:"rack_unit_size"`
 	Created           time.Time `json:"created" faker:"-"`
 	Updated           time.Time `json:"updated" faker:"-"`
 }

--- a/roles_test.go
+++ b/roles_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRackRoleCreateFromStruct(t *testing.T) {
@@ -31,5 +33,5 @@ func TestRackRoleCreateFromStruct(t *testing.T) {
 	assertRequestCount(t, spy.requestCount, 1)
 	assertRequestPath(t, spy.requestPath, "/rack_role")
 	assertRequestMethod(t, spy.requestMethod, "POST")
-	assertData(t, got, want)
+	assert.Equal(t, got, want)
 }

--- a/rooms_integration_test.go
+++ b/rooms_integration_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRoomsAPIIntegration(t *testing.T) {
@@ -21,7 +23,8 @@ func TestRoomsAPIIntegration(t *testing.T) {
 			want.Alias,
 			want.VendorName,
 		)
-		//assertData(t, got, want)
+		assert.NotNil(t, testRoom.ID)
+		// TODO write a functional test here -- perigrin
 	})
 
 	t.Run("Get all rooms", func(t *testing.T) {

--- a/rooms_test.go
+++ b/rooms_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRoomsCreateFromStruct(t *testing.T) {
@@ -31,5 +33,5 @@ func TestRoomsCreateFromStruct(t *testing.T) {
 	assertRequestCount(t, spy.requestCount, 1)
 	assertRequestPath(t, spy.requestPath, "/room")
 	assertRequestMethod(t, spy.requestMethod, "POST")
-	assertData(t, got, want)
+	assert.Equal(t, got, want)
 }

--- a/templates.go
+++ b/templates.go
@@ -260,6 +260,8 @@ Created: {{ .Created }}
 
 const hardwareProductTemplate = `
 ID: {{ .ID }}
+Name: {{ .Name }}
+SKU: {{ .SKU }}
 
 Created: {{ TimeStr .Created }}
 Updated: {{ TimeStr .Updated }}


### PR DESCRIPTION
This PR cleans up the output for the Hardware CLI. I had inadvertently not implemented stringification for the hardware structs in my rush to get something functional out the door.

This also adds tests for the Hardware CLI output, and implements a proof of concept for testing the *other* CLI outputs going forward. 

Finally I cleaned up a couple places that `go vet` was complaining about in the code, and started migrating tests to use `stretchr/testify` because it's output is easier for debugging test failures than my hand rolled output.