### PR TITLE
move to functional configuration for the conch pkg

### DIFF
--- a/cli/builds.go
+++ b/cli/builds.go
@@ -26,7 +26,7 @@ func okBuildRole(role string) bool {
 func buildsCmd(cfg Config) func(cmd *cli.Cmd) {
 	conch := cfg.ConchClient()
 	display := cfg.Renderer()
-	log := cfg.GetLogger()
+	log := cfg
 	return func(cmd *cli.Cmd) {
 		cmd.Before = func() {
 			conch = cfg.ConchClient()

--- a/cli/config_test.go
+++ b/cli/config_test.go
@@ -9,28 +9,9 @@ import (
 	"github.com/joyent/kosh/cli"
 	"github.com/joyent/kosh/conch"
 	"github.com/joyent/kosh/conch/types"
-	"github.com/joyent/kosh/logger"
 
 	"github.com/stretchr/testify/assert"
 )
-
-type config struct {
-	url    string
-	token  string
-	logger logger.Logger
-}
-
-func (c config) GetURL() string           { return c.url }
-func (c config) GetToken() string         { return c.token }
-func (c config) GetLogger() logger.Logger { return c.logger }
-
-func newConfig(URL string) config {
-	return config{
-		URL,
-		"token",
-		logger.New(),
-	}
-}
 
 func TestRender(t *testing.T) {
 	buffer := bytes.NewBufferString("")
@@ -40,7 +21,7 @@ func TestRender(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
-	conch := conch.New(newConfig(ts.URL))
+	conch := conch.New(conch.API(ts.URL))
 
 	tests := []struct {
 		Name string

--- a/cli/users.go
+++ b/cli/users.go
@@ -22,7 +22,7 @@ func profileCmd(cfg Config) func(cmd *cli.Cmd) {
 	return func(cmd *cli.Cmd) {
 		cmd.Action = func() {
 			conch := cfg.ConchClient()
-			log := cfg.GetLogger()
+			log := cfg.Logger
 			log.Debug("display(conch.GetCurrentUser())")
 			display(conch.GetCurrentUser())
 		}
@@ -87,7 +87,7 @@ func userSettingDelete(cfg Config, setting string) func(cmd *cli.Cmd) {
 			if e := conch.DeleteCurrentUserSetting(setting); e != nil {
 				fatal(e)
 			}
-			if !cfg.GetOutputJSON() {
+			if !cfg.OutputJSON {
 				fmt.Println("OK")
 			}
 		}

--- a/conch/builds_test.go
+++ b/conch/builds_test.go
@@ -166,7 +166,7 @@ func TestBuilds(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			}))
 			defer ts.Close()
-			test.Do(conch.New(newConfig(ts.URL)))
+			test.Do(conch.New(conch.API(ts.URL)))
 			assert.True(t, seen, "saw the correct post to conch")
 		})
 	}

--- a/conch/conch_test.go
+++ b/conch/conch_test.go
@@ -7,27 +7,8 @@ import (
 	"testing"
 
 	"github.com/joyent/kosh/conch"
-	"github.com/joyent/kosh/logger"
 	"github.com/stretchr/testify/assert"
 )
-
-type config struct {
-	url    string
-	token  string
-	logger logger.Logger
-}
-
-func (c config) GetURL() string           { return c.url }
-func (c config) GetToken() string         { return c.token }
-func (c config) GetLogger() logger.Logger { return c.logger }
-
-func newConfig(URL string) config {
-	return config{
-		URL,
-		"token",
-		logger.New(),
-	}
-}
 
 func TestDefaultRoutes(t *testing.T) {
 	tests := []struct {
@@ -74,7 +55,7 @@ func TestDefaultRoutes(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			}))
 			defer ts.Close()
-			test.Do(conch.New(newConfig(ts.URL)))
+			test.Do(conch.New(conch.API(ts.URL)))
 			assert.True(t, seen, "saw the correct post to conch")
 		})
 	}

--- a/conch/datacenters_test.go
+++ b/conch/datacenters_test.go
@@ -66,7 +66,7 @@ func TestDatacenterRoutes(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			}))
 			defer ts.Close()
-			test.Do(conch.New(newConfig(ts.URL)))
+			test.Do(conch.New(conch.API(ts.URL)))
 			assert.True(t, seen, "saw the correct post to conch")
 		})
 	}

--- a/conch/deviceReports_test.go
+++ b/conch/deviceReports_test.go
@@ -53,7 +53,7 @@ func TestDeviceReportRoutes(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			}))
 			defer ts.Close()
-			test.Do(conch.New(newConfig(ts.URL)))
+			test.Do(conch.New(conch.API(ts.URL)))
 			assert.True(t, seen, "saw the correct post to conch")
 		})
 	}

--- a/conch/devices_test.go
+++ b/conch/devices_test.go
@@ -185,7 +185,7 @@ func TestDevices(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			}))
 			defer ts.Close()
-			test.Do(conch.New(newConfig(ts.URL)))
+			test.Do(conch.New(conch.API(ts.URL)))
 			assert.True(t, seen, "saw the correct post to conch")
 		})
 	}

--- a/conch/hardwareProducts_test.go
+++ b/conch/hardwareProducts_test.go
@@ -74,7 +74,7 @@ func TestHardwareProductRoutes(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			}))
 			defer ts.Close()
-			test.Do(conch.New(newConfig(ts.URL)))
+			test.Do(conch.New(conch.API(ts.URL)))
 			assert.True(t, seen, "saw the correct post to conch")
 		})
 	}

--- a/conch/hardwareVendors_test.go
+++ b/conch/hardwareVendors_test.go
@@ -51,7 +51,7 @@ func TestHardwareVendorRoutes(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			}))
 			defer ts.Close()
-			test.Do(conch.New(newConfig(ts.URL)))
+			test.Do(conch.New(conch.API(ts.URL)))
 			assert.True(t, seen, "saw the correct post to conch")
 		})
 	}

--- a/conch/organizations_test.go
+++ b/conch/organizations_test.go
@@ -82,7 +82,7 @@ func TestOrganizationRoutes(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			}))
 			defer ts.Close()
-			test.Do(conch.New(newConfig(ts.URL)))
+			test.Do(conch.New(conch.API(ts.URL)))
 			assert.True(t, seen, "saw the correct post to conch")
 		})
 	}

--- a/conch/rackRoles_test.go
+++ b/conch/rackRoles_test.go
@@ -61,7 +61,7 @@ func TestRackRole(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			}))
 			defer ts.Close()
-			test.Do(conch.New(newConfig(ts.URL)))
+			test.Do(conch.New(conch.API(ts.URL)))
 			assert.True(t, seen, "saw the correct post to conch")
 		})
 	}

--- a/conch/racks_test.go
+++ b/conch/racks_test.go
@@ -135,7 +135,7 @@ func TestRacks(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			}))
 			defer ts.Close()
-			test.Do(conch.New(newConfig(ts.URL)))
+			test.Do(conch.New(conch.API(ts.URL)))
 			assert.True(t, seen, "saw the correct post to conch")
 		})
 	}

--- a/conch/relays_test.go
+++ b/conch/relays_test.go
@@ -57,7 +57,7 @@ func TestRelayRoutes(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			}))
 			defer ts.Close()
-			test.Do(conch.New(newConfig(ts.URL)))
+			test.Do(conch.New(conch.API(ts.URL)))
 			assert.True(t, seen, "saw the correct post to conch")
 		})
 	}

--- a/conch/rooms_test.go
+++ b/conch/rooms_test.go
@@ -204,7 +204,7 @@ func TestRooms(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			}))
 			defer ts.Close()
-			test.Do(conch.New(newConfig(ts.URL)))
+			test.Do(conch.New(conch.API(ts.URL)))
 			assert.True(t, seen, "saw the correct post to conch")
 		})
 	}

--- a/conch/users_test.go
+++ b/conch/users_test.go
@@ -151,7 +151,7 @@ func TestUser(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			}))
 			defer ts.Close()
-			test.Do(conch.New(newConfig(ts.URL)))
+			test.Do(conch.New(conch.API(ts.URL)))
 			assert.True(t, seen, "saw the correct post to conch")
 		})
 	}

--- a/conch/validations_test.go
+++ b/conch/validations_test.go
@@ -77,7 +77,7 @@ func TestValidationRoutes(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			}))
 			defer ts.Close()
-			test.Do(conch.New(newConfig(ts.URL)))
+			test.Do(conch.New(conch.API(ts.URL)))
 			assert.True(t, seen, "saw the correct post to conch")
 		})
 	}


### PR DESCRIPTION
Moving to a functional configuration API ( See https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis ) makes the configuration for the conch package much much more straight forward and simpler. As a knock on it reduced the complexity of configuring the CLI as well.