### PR TITLE
restore KOSH_ENV

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -19,9 +19,9 @@ type Config struct {
 	Version string
 	GitRev  string
 
-	ConchURL         string
-	ConchToken       string
-	ConchEnvironment string
+	ConchURL   string
+	ConchToken string
+	ConchENV   string
 
 	OutputJSON bool
 
@@ -44,9 +44,9 @@ const configTemplate = `
 * Version: {{ .Version }}
 * GitRev: {{ .GitRev }}
 
+* ConchENV: {{ .ConchENV }}
 * ConchURL: {{ .ConchURL }}
 * ConchToken: {{ .ConchToken }}
-* ConchEnvironment: {{ .ConchEnvironment }}
 
 * OutputJSON: {{ .OutputJSON }}
 


### PR DESCRIPTION
In 3.1.0 we dropped KOSH_ENV because the underlying things it did, we
don't (currently) do any longer and there was an issue where it would
override KOSH_URL.

However for compatibility reasons we shouldn't have dropped it,
additionally it's useful for a shorthand for prodduction/staging/edge
rather than remembering the URLs.

This brings back teh behavior but gates it so that if the user
explicitly set KOSH_URL it isn't overridden by KOSH_ENV.

Closes #71