### PR TITLE
tag as a v3 module for go.mod

### DIFF
--- a/cli/builds.go
+++ b/cli/builds.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 
 	cli "github.com/jawher/mow.cli"
-	"github.com/joyent/kosh/conch"
-	"github.com/joyent/kosh/conch/types"
+	"github.com/joyent/kosh/v3/conch"
+	"github.com/joyent/kosh/v3/conch/types"
 )
 
 var buildRoleList = []string{"admin", "rw", "ro"}

--- a/cli/config.go
+++ b/cli/config.go
@@ -8,10 +8,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/joyent/kosh/conch"
-	"github.com/joyent/kosh/logger"
-	"github.com/joyent/kosh/tables"
-	"github.com/joyent/kosh/template"
+	"github.com/joyent/kosh/v3/conch"
+	"github.com/joyent/kosh/v3/logger"
+	"github.com/joyent/kosh/v3/tables"
+	"github.com/joyent/kosh/v3/template"
 )
 
 // Config is the default configuration struct

--- a/cli/config_test.go
+++ b/cli/config_test.go
@@ -6,9 +6,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/joyent/kosh/cli"
-	"github.com/joyent/kosh/conch"
-	"github.com/joyent/kosh/conch/types"
+	"github.com/joyent/kosh/v3/cli"
+	"github.com/joyent/kosh/v3/conch"
+	"github.com/joyent/kosh/v3/conch/types"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cli/datacenters.go
+++ b/cli/datacenters.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	cli "github.com/jawher/mow.cli"
-	"github.com/joyent/kosh/conch"
-	"github.com/joyent/kosh/conch/types"
+	"github.com/joyent/kosh/v3/conch"
+	"github.com/joyent/kosh/v3/conch/types"
 )
 
 func datacentersCmd(cmd *cli.Cmd) {

--- a/cli/device_reports.go
+++ b/cli/device_reports.go
@@ -2,7 +2,7 @@ package cli
 
 import (
 	cli "github.com/jawher/mow.cli"
-	"github.com/joyent/kosh/conch"
+	"github.com/joyent/kosh/v3/conch"
 )
 
 func deviceReportCmd(cmd *cli.Cmd) {

--- a/cli/devices.go
+++ b/cli/devices.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	cli "github.com/jawher/mow.cli"
-	"github.com/joyent/kosh/conch"
+	"github.com/joyent/kosh/v3/conch"
 )
 
 func devicesCmd(cmd *cli.Cmd) {

--- a/cli/hardware.go
+++ b/cli/hardware.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	cli "github.com/jawher/mow.cli"
-	"github.com/joyent/kosh/conch"
-	"github.com/joyent/kosh/conch/types"
+	"github.com/joyent/kosh/v3/conch"
+	"github.com/joyent/kosh/v3/conch/types"
 )
 
 func cmdCreateProduct(cmd *cli.Cmd) {

--- a/cli/organizations.go
+++ b/cli/organizations.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	cli "github.com/jawher/mow.cli"
-	"github.com/joyent/kosh/conch"
-	"github.com/joyent/kosh/conch/types"
+	"github.com/joyent/kosh/v3/conch"
+	"github.com/joyent/kosh/v3/conch/types"
 )
 
 func organizationsCmd(cmd *cli.Cmd) {

--- a/cli/racks.go
+++ b/cli/racks.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	cli "github.com/jawher/mow.cli"
-	"github.com/joyent/kosh/conch"
-	"github.com/joyent/kosh/conch/types"
+	"github.com/joyent/kosh/v3/conch"
+	"github.com/joyent/kosh/v3/conch/types"
 )
 
 func racksCmd(cmd *cli.Cmd) {

--- a/cli/relays.go
+++ b/cli/relays.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	cli "github.com/jawher/mow.cli"
-	"github.com/joyent/kosh/conch"
-	"github.com/joyent/kosh/conch/types"
+	"github.com/joyent/kosh/v3/conch"
+	"github.com/joyent/kosh/v3/conch/types"
 )
 
 func relaysCmd(cmd *cli.Cmd) {

--- a/cli/roles.go
+++ b/cli/roles.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 
 	cli "github.com/jawher/mow.cli"
-	"github.com/joyent/kosh/conch"
-	"github.com/joyent/kosh/conch/types"
+	"github.com/joyent/kosh/v3/conch"
+	"github.com/joyent/kosh/v3/conch/types"
 )
 
 func rolesCmd(cmd *cli.Cmd) {

--- a/cli/rooms.go
+++ b/cli/rooms.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 
 	cli "github.com/jawher/mow.cli"
-	"github.com/joyent/kosh/conch"
-	"github.com/joyent/kosh/conch/types"
+	"github.com/joyent/kosh/v3/conch"
+	"github.com/joyent/kosh/v3/conch/types"
 )
 
 func roomsCmd(cmd *cli.Cmd) {

--- a/cli/schema.go
+++ b/cli/schema.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	cli "github.com/jawher/mow.cli"
-	"github.com/joyent/kosh/conch"
+	"github.com/joyent/kosh/v3/conch"
 )
 
 func schemaCmd(cmd *cli.Cmd) {

--- a/cli/users.go
+++ b/cli/users.go
@@ -2,7 +2,7 @@ package cli
 
 import (
 	cli "github.com/jawher/mow.cli"
-	"github.com/joyent/kosh/conch/types"
+	"github.com/joyent/kosh/v3/conch/types"
 )
 
 func whoamiCmd(cmd *cli.Cmd) { profileCmd(cmd) }

--- a/cli/validations.go
+++ b/cli/validations.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 
 	cli "github.com/jawher/mow.cli"
-	"github.com/joyent/kosh/conch"
-	"github.com/joyent/kosh/conch/types"
+	"github.com/joyent/kosh/v3/conch"
+	"github.com/joyent/kosh/v3/conch/types"
 )
 
 func validationCmd(cmd *cli.Cmd) {

--- a/conch/builds.go
+++ b/conch/builds.go
@@ -1,6 +1,6 @@
 package conch
 
-import "github.com/joyent/kosh/conch/types"
+import "github.com/joyent/kosh/v3/conch/types"
 
 // GetAllBuilds retrieves a list of all Builds
 // GET /builds

--- a/conch/builds_test.go
+++ b/conch/builds_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/joyent/kosh/conch"
-	"github.com/joyent/kosh/conch/types"
+	"github.com/joyent/kosh/v3/conch"
+	"github.com/joyent/kosh/v3/conch/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/conch/client.go
+++ b/conch/client.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/dghubble/sling"
-	"github.com/joyent/kosh/logger"
+	"github.com/joyent/kosh/v3/logger"
 )
 
 var defaultTransport = &http.Transport{

--- a/conch/client_test.go
+++ b/conch/client_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/dghubble/sling"
 	"github.com/dnaeon/go-vcr/cassette"
 	"github.com/dnaeon/go-vcr/recorder"
-	"github.com/joyent/kosh/conch"
-	"github.com/joyent/kosh/logger"
+	"github.com/joyent/kosh/v3/conch"
+	"github.com/joyent/kosh/v3/logger"
 )
 
 func NewTestClient(fixture string) *conch.Client {

--- a/conch/conch.go
+++ b/conch/conch.go
@@ -5,7 +5,7 @@ this library wraps, please see: https://joyent.github.io/conch-api/
 */
 package conch
 
-import "github.com/joyent/kosh/conch/types"
+import "github.com/joyent/kosh/v3/conch/types"
 
 // Ping ( GET /ping ) checks to see if the API server is online and reachable.
 // See also https://joyent.github.io/conch-api/modules/Conch::Route#get-ping

--- a/conch/conch_test.go
+++ b/conch/conch_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/joyent/kosh/conch"
+	"github.com/joyent/kosh/v3/conch"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/conch/datacenters.go
+++ b/conch/datacenters.go
@@ -1,6 +1,6 @@
 package conch
 
-import "github.com/joyent/kosh/conch/types"
+import "github.com/joyent/kosh/v3/conch/types"
 
 // GetAllDatacenters ( GET /dc ) retrieves a list of all datacenters
 func (c *Client) GetAllDatacenters() (dc types.Datacenters) {

--- a/conch/datacenters_test.go
+++ b/conch/datacenters_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/joyent/kosh/conch"
-	"github.com/joyent/kosh/conch/types"
+	"github.com/joyent/kosh/v3/conch"
+	"github.com/joyent/kosh/v3/conch/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/conch/deviceReports.go
+++ b/conch/deviceReports.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"io"
 
-	"github.com/joyent/kosh/conch/types"
+	"github.com/joyent/kosh/v3/conch/types"
 )
 
 // SendDeviceReport (POST /device_report) reads a new device report from an

--- a/conch/deviceReports_test.go
+++ b/conch/deviceReports_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/joyent/kosh/conch"
+	"github.com/joyent/kosh/v3/conch"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/conch/devices.go
+++ b/conch/devices.go
@@ -3,7 +3,7 @@ package conch
 import (
 	"fmt"
 
-	"github.com/joyent/kosh/conch/types"
+	"github.com/joyent/kosh/v3/conch/types"
 )
 
 // FindDevicesBySetting (GET /device?:key=:value) returns a list of devices

--- a/conch/devices_test.go
+++ b/conch/devices_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/joyent/kosh/conch"
-	"github.com/joyent/kosh/conch/types"
+	"github.com/joyent/kosh/v3/conch"
+	"github.com/joyent/kosh/v3/conch/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/conch/hardwareProducts.go
+++ b/conch/hardwareProducts.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"io"
 
-	"github.com/joyent/kosh/conch/types"
+	"github.com/joyent/kosh/v3/conch/types"
 )
 
 // GetHardwareProducts (GET /hardware_product) returns a list of known hardware

--- a/conch/hardwareProducts_test.go
+++ b/conch/hardwareProducts_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/joyent/kosh/conch"
-	"github.com/joyent/kosh/conch/types"
+	"github.com/joyent/kosh/v3/conch"
+	"github.com/joyent/kosh/v3/conch/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/conch/hardwareVendors.go
+++ b/conch/hardwareVendors.go
@@ -1,6 +1,6 @@
 package conch
 
-import "github.com/joyent/kosh/conch/types"
+import "github.com/joyent/kosh/v3/conch/types"
 
 // GetAllHardwareVendors (GET /hardware_vendor) returns a list of all hardware
 // vendors

--- a/conch/hardwareVendors_test.go
+++ b/conch/hardwareVendors_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/joyent/kosh/conch"
-	"github.com/joyent/kosh/conch/types"
+	"github.com/joyent/kosh/v3/conch"
+	"github.com/joyent/kosh/v3/conch/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/conch/organizations.go
+++ b/conch/organizations.go
@@ -1,6 +1,6 @@
 package conch
 
-import "github.com/joyent/kosh/conch/types"
+import "github.com/joyent/kosh/v3/conch/types"
 
 // GetAllOrganizations (GET /organization) returns the list of organizations
 func (c *Client) GetAllOrganizations() (orgs types.Organizations) {

--- a/conch/organizations_test.go
+++ b/conch/organizations_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/joyent/kosh/conch"
-	"github.com/joyent/kosh/conch/types"
+	"github.com/joyent/kosh/v3/conch"
+	"github.com/joyent/kosh/v3/conch/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/conch/rackRoles.go
+++ b/conch/rackRoles.go
@@ -1,6 +1,6 @@
 package conch
 
-import "github.com/joyent/kosh/conch/types"
+import "github.com/joyent/kosh/v3/conch/types"
 
 // GetAllRackRoles (GET /rack_role) returns a list of all rack roles
 func (c *Client) GetAllRackRoles() (roles types.RackRoles) {

--- a/conch/rackRoles_test.go
+++ b/conch/rackRoles_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/joyent/kosh/conch"
-	"github.com/joyent/kosh/conch/types"
+	"github.com/joyent/kosh/v3/conch"
+	"github.com/joyent/kosh/v3/conch/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/conch/racks.go
+++ b/conch/racks.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"io"
 
-	"github.com/joyent/kosh/conch/types"
+	"github.com/joyent/kosh/v3/conch/types"
 )
 
 // CreateRack (POST /rack) creates a new rack

--- a/conch/racks_test.go
+++ b/conch/racks_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/joyent/kosh/conch"
-	"github.com/joyent/kosh/conch/types"
+	"github.com/joyent/kosh/v3/conch"
+	"github.com/joyent/kosh/v3/conch/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/conch/relays.go
+++ b/conch/relays.go
@@ -1,6 +1,6 @@
 package conch
 
-import "github.com/joyent/kosh/conch/types"
+import "github.com/joyent/kosh/v3/conch/types"
 
 // RegisterRelay (POST /relay/:relay_serial_number/register)
 // registers a relay with the given serial number

--- a/conch/relays_test.go
+++ b/conch/relays_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/joyent/kosh/conch"
-	"github.com/joyent/kosh/conch/types"
+	"github.com/joyent/kosh/v3/conch"
+	"github.com/joyent/kosh/v3/conch/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/conch/rooms.go
+++ b/conch/rooms.go
@@ -1,6 +1,6 @@
 package conch
 
-import "github.com/joyent/kosh/conch/types"
+import "github.com/joyent/kosh/v3/conch/types"
 
 // GetAllRooms (GET /room) returns a list of all datacenter rooms
 func (c *Client) GetAllRooms() (rooms types.DatacenterRoomsDetailed) {

--- a/conch/rooms_test.go
+++ b/conch/rooms_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/joyent/kosh/conch"
-	"github.com/joyent/kosh/conch/types"
+	"github.com/joyent/kosh/v3/conch"
+	"github.com/joyent/kosh/v3/conch/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/conch/types/templates.go
+++ b/conch/types/templates.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/joyent/kosh/tables"
-	"github.com/joyent/kosh/template"
+	"github.com/joyent/kosh/v3/tables"
+	"github.com/joyent/kosh/v3/template"
 )
 
 func (bl Builds) Len() int           { return len(bl) }

--- a/conch/users.go
+++ b/conch/users.go
@@ -1,6 +1,6 @@
 package conch
 
-import "github.com/joyent/kosh/conch/types"
+import "github.com/joyent/kosh/v3/conch/types"
 
 // GetCurrentUser (GET /user/me) retrieves the user associated with the current
 // authentication

--- a/conch/users_test.go
+++ b/conch/users_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/joyent/kosh/conch"
-	"github.com/joyent/kosh/conch/types"
+	"github.com/joyent/kosh/v3/conch"
+	"github.com/joyent/kosh/v3/conch/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/conch/validations.go
+++ b/conch/validations.go
@@ -1,6 +1,6 @@
 package conch
 
-import "github.com/joyent/kosh/conch/types"
+import "github.com/joyent/kosh/v3/conch/types"
 
 // GetValidations ( GET /validation ) returns a list of all validations from
 // the server. See also

--- a/conch/validations_test.go
+++ b/conch/validations_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/joyent/kosh/conch"
-	"github.com/joyent/kosh/conch/types"
+	"github.com/joyent/kosh/v3/conch"
+	"github.com/joyent/kosh/v3/conch/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/joyent/kosh
+module github.com/joyent/kosh/v3
 
 go 1.15
 

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/joyent/kosh/cli"
+	"github.com/joyent/kosh/v3/cli"
 )
 
 var (

--- a/template/template.go
+++ b/template/template.go
@@ -10,7 +10,7 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/joyent/kosh/tables"
+	"github.com/joyent/kosh/v3/tables"
 )
 
 const dateFormat = "2006-01-02 15:04:05 -0700 MST"


### PR DESCRIPTION
To make this work as a module for other go applications we need to tell
them that we're actually a v3 module.